### PR TITLE
Add getCursor handler to Atlas to show pointer cursor on pickable features

### DIFF
--- a/app/components/atlas.client.tsx
+++ b/app/components/atlas.client.tsx
@@ -29,6 +29,12 @@ export function Atlas() {
         communityDistrictsLayer,
         cityCouncilDistrictsLayer,
       ]}
+      getCursor={({ isDragging, isHovering }) => {
+        if (isDragging) {
+          return "grabbing";
+        }
+        return isHovering ? "pointer" : "grab";
+      }}
     >
       <Map
         mapStyle={"https://tiles.planninglabs.nyc/styles/positron/style.json"}


### PR DESCRIPTION
This PR is a small change that adds a custom [getCursor](https://deck.gl/docs/api-reference/core/deck#getcursor) handler to the `<Deck>` instance in `Atlas`. I noticed that with #23, the cursor still showed up as "drag" even when the user was hovering over pickable features. I think this change provides feedback to the user that they can click on projects.