### PR TITLE
Add separate _index page for mobile filtermenu layout and connect district type to query params

### DIFF
--- a/app/components/FilterMenu.tsx
+++ b/app/components/FilterMenu.tsx
@@ -1,4 +1,5 @@
-import { useState, FormEvent } from "react";
+import { FormEvent } from "react";
+import { useSearchParams, useNavigate } from "@remix-run/react";
 import {
   Button,
   Flex,
@@ -12,10 +13,13 @@ import {
 } from "@nycplanning/streetscape";
 import { ChevronDownIcon } from "@chakra-ui/icons";
 
-export type GeographyType = "cd" | "ccd" | null;
-
-export const FilterMenu = ({ onClose }: FilterMenuProps) => {
-  const [geographyType, setGeorgaphyType] = useState<GeographyType>("cd");
+export const FilterMenu = ({
+  onClose = () => {
+    return;
+  },
+}: FilterMenuProps) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const districtType = searchParams.get("districtType");
   return (
     <Flex
       borderRadius={"base"}
@@ -49,25 +53,40 @@ export const FilterMenu = ({ onClose }: FilterMenuProps) => {
             borderBottomWidth={"1px"}
             borderBottomColor={"gray.400"}
           >
-            Filter by Geography
+            Filter by District
           </Heading>
         </Show>
-        <FormControl id="geographyType">
-          <FormLabel>Geography Type</FormLabel>
+        <FormControl id="districtType">
+          <FormLabel
+            onClick={() => {
+              onClose();
+            }}
+          >
+            District Type
+          </FormLabel>
           <Select
             placeholder="-Select-"
             variant="base"
             onChange={(e: FormEvent<HTMLSelectElement>) => {
-              setGeorgaphyType(e.currentTarget.value as GeographyType);
+              if (e.currentTarget.value === "") {
+                setSearchParams({}, { replace: true });
+              } else {
+                setSearchParams(
+                  {
+                    districtType: e.currentTarget.value,
+                  },
+                  { replace: true },
+                );
+              }
             }}
-            value={geographyType}
+            value={districtType === null ? "" : districtType}
           >
             <option value={"cd"}>Community District</option>
             <option value={"ccd"}>City Council District</option>
           </Select>
         </FormControl>
         <HStack spacing={2} width={"full"}>
-          {geographyType !== "ccd" ? (
+          {districtType !== "ccd" ? (
             <FormControl id="borough">
               <FormLabel>Borough</FormLabel>
               <Select
@@ -78,7 +97,7 @@ export const FilterMenu = ({ onClose }: FilterMenuProps) => {
             </FormControl>
           ) : null}
           <FormControl id="district">
-            <FormLabel>District</FormLabel>
+            <FormLabel>District Number</FormLabel>
             <Select
               placeholder="-Select-"
               variant="base"
@@ -87,7 +106,7 @@ export const FilterMenu = ({ onClose }: FilterMenuProps) => {
           </FormControl>
         </HStack>
         <Button width="full" isDisabled={true}>
-          Go to Selected Geography
+          Go to Selected District
         </Button>
       </Flex>
     </Flex>
@@ -95,5 +114,5 @@ export const FilterMenu = ({ onClose }: FilterMenuProps) => {
 };
 
 export interface FilterMenuProps {
-  onClose: () => void;
+  onClose?: () => void;
 }

--- a/app/components/Overlay.tsx
+++ b/app/components/Overlay.tsx
@@ -1,10 +1,12 @@
-import { Flex, Button, Hide, Show } from "@nycplanning/streetscape";
-import { ReactNode, useState } from "react";
+import { Flex, Show } from "@nycplanning/streetscape";
+import { ReactNode } from "react";
 import { FilterMenu } from "./FilterMenu";
 
-export const Overlay = () => {
-  const [shouldShowFilterMenu, setShouldShowFilterMenu] = useState(false);
+export interface OverlayProps {
+  children: ReactNode;
+}
 
+export const Overlay = ({ children }: OverlayProps) => {
   return (
     <Flex
       position="relative"
@@ -12,7 +14,7 @@ export const Overlay = () => {
       height={"100vh"}
       width={"100vw"}
       direction={{ base: "column", lg: "row" }}
-      justify={{ base: "flex-end", lg: "flex-start" }}
+      justify={{ base: "flex-end", lg: "space-between" }}
       align={{ base: "center", lg: "flex-start" }}
       pointerEvents={"none"}
       sx={{
@@ -22,30 +24,9 @@ export const Overlay = () => {
       }}
     >
       <Show above="lg">
-        <FilterMenu onClose={() => setShouldShowFilterMenu(false)} />
+        <FilterMenu />
       </Show>
-      {shouldShowFilterMenu ? (
-        <Hide above="lg">
-          <FilterMenu onClose={() => setShouldShowFilterMenu(false)} />
-        </Hide>
-      ) : null}
-      {!shouldShowFilterMenu ? (
-        <Hide above="lg">
-          <Button
-            width={"full"}
-            maxW={"21.25rem"}
-            onClick={() => {
-              setShouldShowFilterMenu(true);
-            }}
-          >
-            Filter by Geography
-          </Button>
-        </Hide>
-      ) : null}
+      {children}
     </Flex>
   );
 };
-
-export interface OverlayProps {
-  children: ReactNode;
-}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -46,11 +46,13 @@ export default function App() {
   return (
     <Document>
       <StreetscapeProvider>
-        <Outlet />
         <ClientOnly>
           {() => (
             <>
-              <Atlas /> <Overlay />
+              <Atlas />{" "}
+              <Overlay>
+                <Outlet />
+              </Overlay>
             </>
           )}
         </ClientOnly>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,0 +1,28 @@
+import { Hide, Button } from "@nycplanning/streetscape";
+import { FilterMenu } from "../components/FilterMenu";
+import { useState } from "react";
+
+export default function Index() {
+  const [shouldShowFilterMenu, setShouldShowFilterMenu] = useState(false);
+  return (
+    <Hide above="lg">
+      {shouldShowFilterMenu ? (
+        <FilterMenu
+          onClose={() => {
+            setShouldShowFilterMenu(false);
+          }}
+        />
+      ) : (
+        <Button
+          width={"full"}
+          maxW={"21.25rem"}
+          onClick={() => {
+            setShouldShowFilterMenu(true);
+          }}
+        >
+          Filter by Geography
+        </Button>
+      )}
+    </Hide>
+  );
+}


### PR DESCRIPTION
## Summary

1. Adds new root `_index` route that renders a `<FilterMenu>` and the `Show Geography filter` button only on mobile. In combination with the `<FilterMenu>` instance in `root.tsx`, this is mean to accomplish the desired behavior where the filter menu is always shown on desktop sizes but is hidden on mobile on non-root routes (so that content panel can be shown).
2. Connected the district type dropdown to store it's state in query param.

This PR is intended to set up just enough of the FilterMenu component to unblock other works, primarily #12 and #13 