### PR TITLE
13 Show Community Districts layer on map

### DIFF
--- a/app/components/atlas.client.tsx
+++ b/app/components/atlas.client.tsx
@@ -1,7 +1,7 @@
 import { DeckGL } from "@deck.gl/react";
 import { Map } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
-import { useCapitalProjectsLayer } from "./layers";
+import { useCapitalProjectsLayer, useCommunityDistrictsLayer } from "./layers";
 
 const INITIAL_VIEW_STATE = {
   longitude: -74.0008,
@@ -13,12 +13,13 @@ const INITIAL_VIEW_STATE = {
 
 export function Atlas() {
   const capitalProjectsLayer = useCapitalProjectsLayer();
+  const communityDistrictsLayer = useCommunityDistrictsLayer();
   return (
     <DeckGL
       initialViewState={INITIAL_VIEW_STATE}
       controller={true}
       style={{ height: "100vh", width: "100vw" }}
-      layers={[capitalProjectsLayer]}
+      layers={[capitalProjectsLayer, communityDistrictsLayer]}
     >
       <Map
         mapStyle={"https://tiles.planninglabs.nyc/styles/positron/style.json"}

--- a/app/components/layers/index.tsx
+++ b/app/components/layers/index.tsx
@@ -1,1 +1,2 @@
 export { useCapitalProjectsLayer } from "./useCapitalProjectsLayer.client";
+export { useCommunityDistrictsLayer } from "./useCommunityDistrictsLayer.client";

--- a/app/components/layers/useCommunityDistrictsLayer.client.tsx
+++ b/app/components/layers/useCommunityDistrictsLayer.client.tsx
@@ -18,23 +18,18 @@ export function useCommunityDistrictsLayer() {
     visible: districtType === "cd",
     uniqueIdProperty: "boroughIdCommunityDistrictId",
     pickable: true,
-    getFillColor: (f) => {
-      // If CommunityDistrictId > 18, the area represents a Parks, not a Community District
-      if (parseInt(f.properties.boroughIdCommunityDistrictId.slice(-2)) > 18) {
-        return [217, 107, 39, 0];
-      }
-      return [217, 107, 39, 0];
-    },
     getPointRadius: 5,
+    filled: false,
     getLineColor: [113, 128, 150, 255],
-    getLineWidth: 30,
+    getLineWidth: 3,
+    lineWidthUnits: "pixels",
     pointType: "text",
-    getText: (f: any) => {
-      // If CommunityDistrictId > 18, the area represents a Parks, not a Community District
-      if (parseInt(f.properties.boroughIdCommunityDistrictId.slice(-2)) > 18) {
+    getText: ({ properties }: { properties: CommunityDistrictProperties }) => {
+      // If CommunityDistrictId > 18, the area represents a Park, not a Community District
+      if (parseInt(properties.boroughIdCommunityDistrictId.slice(-2)) > 18) {
         return null;
       }
-      return `${f.properties.abbr} ${parseInt(f.properties.boroughIdCommunityDistrictId.slice(-2))}`;
+      return `${properties.abbr} ${parseInt(properties.boroughIdCommunityDistrictId.slice(-2))}`;
     },
     getTextColor: [98, 98, 98, 255],
     textFontFamily: "Helvetica Neue, Arial, sans-serif",

--- a/app/components/layers/useCommunityDistrictsLayer.client.tsx
+++ b/app/components/layers/useCommunityDistrictsLayer.client.tsx
@@ -1,0 +1,48 @@
+import { MVTLayer } from "@deck.gl/geo-layers";
+import { useSearchParams } from "@remix-run/react";
+
+export interface CommunityDistrictProperties {
+  boroughIdCommunityDistrictId: string;
+  layerName: string;
+  abbr: string | null;
+}
+export function useCommunityDistrictsLayer() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const districtType = searchParams.get("districtType");
+
+  return new MVTLayer<CommunityDistrictProperties>({
+    id: "CommunityDistricts",
+    data: [
+      `${import.meta.env.VITE_ZONING_API_URL}/api/community-districts/{z}/{x}/{y}.pbf`,
+    ],
+    visible: districtType === "cd",
+    uniqueIdProperty: "boroughIdCommunityDistrictId",
+    pickable: true,
+    getFillColor: (f) => {
+      // If CommunityDistrictId > 18, the area represents a Parks, not a Community District
+      if (parseInt(f.properties.boroughIdCommunityDistrictId.slice(-2)) > 18) {
+        return [217, 107, 39, 0];
+      }
+      return [217, 107, 39, 0];
+    },
+    getPointRadius: 5,
+    getLineColor: [113, 128, 150, 255],
+    getLineWidth: 30,
+    pointType: "text",
+    getText: (f: any) => {
+      // If CommunityDistrictId > 18, the area represents a Parks, not a Community District
+      if (parseInt(f.properties.boroughIdCommunityDistrictId.slice(-2)) > 18) {
+        return null;
+      }
+      return `${f.properties.abbr} ${parseInt(f.properties.boroughIdCommunityDistrictId.slice(-2))}`;
+    },
+    getTextColor: [98, 98, 98, 255],
+    textFontFamily: "Helvetica Neue, Arial, sans-serif",
+    getTextSize: 15,
+    textFontSettings: {
+      sdf: true,
+    },
+    textOutlineColor: [255, 255, 255, 255],
+    textOutlineWidth: 2,
+  });
+}


### PR DESCRIPTION
When user selects "Community Districts" from District Type dropdown in FilterMenu component, user sees CD outlines and labels on the map.
District boundary styles match [specs in Figma](https://www.figma.com/design/LYHHoPop9l0jpEivk5CFzJ/Capital-Projects-Portal?node-id=670-5575&t=bHnqp3D5d54Ghn2t-0).

Completes #13 