### PR TITLE
33 Add map zoom and bearing controls

### DIFF
--- a/app/components/atlas.client.tsx
+++ b/app/components/atlas.client.tsx
@@ -30,7 +30,9 @@ export function Atlas() {
 
   const isMobile = useMediaQuery("(max-width: 767px)")[0];
   const widgetPlacement = isMobile ? "top-right" : "bottom-right";
-  const widgetStyles = isMobile ? {} : { position: "relative", bottom: "2rem" };
+  const widgetStyles = isMobile
+    ? {}
+    : { position: "relative", bottom: "4.5rem" };
 
   const ZoomControls = new ZoomWidget({
     id: "zoom",
@@ -78,6 +80,25 @@ export function Atlas() {
       <Map
         mapStyle={"https://tiles.planninglabs.nyc/styles/positron/style.json"}
       ></Map>
+      <img
+        style={
+          isMobile
+            ? {
+                position: "absolute",
+                top: "0.5rem",
+                left: "0.5rem",
+                height: "2rem",
+              }
+            : {
+                position: "absolute",
+                bottom: "2.5rem",
+                right: "1rem",
+                height: "2rem",
+              }
+        }
+        alt="NYC Planning"
+        src="https://raw.githubusercontent.com/NYCPlanning/dcp-logo/master/dcp_logo_772.png"
+      />
     </DeckGL>
   );
 }

--- a/app/components/atlas.client.tsx
+++ b/app/components/atlas.client.tsx
@@ -1,6 +1,9 @@
 import { DeckGL } from "@deck.gl/react";
 import { Map } from "react-map-gl/maplibre";
+import { ZoomWidget, CompassWidget } from "@deck.gl/widgets";
+import { useMediaQuery } from "@nycplanning/streetscape";
 import "maplibre-gl/dist/maplibre-gl.css";
+import "@deck.gl/widgets/stylesheet.css";
 import { useState } from "react";
 import {
   useCapitalProjectsLayer,
@@ -24,6 +27,21 @@ export function Atlas() {
   const capitalProjectsLayer = useCapitalProjectsLayer();
   const communityDistrictsLayer = useCommunityDistrictsLayer();
   const cityCouncilDistrictsLayer = useCityCouncilDistrictsLayer();
+
+  const isMobile = useMediaQuery("(max-width: 767px)")[0];
+  const widgetPlacement = isMobile ? "top-right" : "bottom-right";
+  const widgetStyles = isMobile ? {} : { position: "relative", bottom: "2rem" };
+
+  const ZoomControls = new ZoomWidget({
+    id: "zoom",
+    placement: widgetPlacement,
+    style: widgetStyles,
+  });
+  const CompassControls = new CompassWidget({
+    id: "compass",
+    placement: widgetPlacement,
+    style: widgetStyles,
+  });
 
   const [viewState, setViewState] = useState<MapViewState>(INITIAL_VIEW_STATE);
 
@@ -55,6 +73,7 @@ export function Atlas() {
         }
         return isHovering ? "pointer" : "grab";
       }}
+      widgets={[ZoomControls, CompassControls]}
     >
       <Map
         mapStyle={"https://tiles.planninglabs.nyc/styles/positron/style.json"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "dependencies": {
         "@chakra-ui/icons": "^2.1.1",
         "@deck.gl/core": "^9.0.20",
-        "@deck.gl/geo-layers": "^9.0.19",
-        "@deck.gl/react": "^9.0.19",
+        "@deck.gl/geo-layers": "^9.0.20",
+        "@deck.gl/react": "^9.0.20",
+        "@deck.gl/widgets": "^9.0.20",
         "@emotion/react": "^11.11.3",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.11.0",
@@ -2523,10 +2524,9 @@
       }
     },
     "node_modules/@deck.gl/geo-layers": {
-      "version": "9.0.19",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.0.19.tgz",
-      "integrity": "sha512-8vpEKMPmtbYrZq6yIbpJUNaT+WSHUsXA/viS+OBAep8IkMJgkftvee13Tgd7h1O02AU9hW0ppDtZGbk3ROZf5A==",
-      "license": "MIT",
+      "version": "9.0.20",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.0.20.tgz",
+      "integrity": "sha512-lO6JW5abwvNvRjrRMlroLkL+UtK+o3MXiyp9g5s0WoXy+KtJ9D10OQ02GpCw0L48udbpO42Cmpg3imcZdO66Dg==",
       "dependencies": {
         "@loaders.gl/3d-tiles": "^4.2.0",
         "@loaders.gl/gis": "^4.2.0",
@@ -2595,14 +2595,24 @@
       }
     },
     "node_modules/@deck.gl/react": {
-      "version": "9.0.19",
-      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-9.0.19.tgz",
-      "integrity": "sha512-ndlOKQrHmA9iDJSWfaZI0ssFuc6SBUvLJ+hk8rxyH3B4UA6pAa8qzfK2NCwmzR3+g3FBz5FN1xA9o4GWrsAplA==",
-      "license": "MIT",
+      "version": "9.0.20",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-9.0.20.tgz",
+      "integrity": "sha512-3r4Jhwu22qgq0r/gs+S+QixpzikmhvBWhpq+oR8s2de4KP9njVO5GUnvmtjz8927R83WOYjDnPEO3oFWHLp+eA==",
       "peerDependencies": {
         "@deck.gl/core": "^9.0.0",
         "react": ">=16.3.0",
         "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/@deck.gl/widgets": {
+      "version": "9.0.20",
+      "resolved": "https://registry.npmjs.org/@deck.gl/widgets/-/widgets-9.0.20.tgz",
+      "integrity": "sha512-lXlgygv4MhU+K5wD5wlyALBuzElv6NjrC+LrZVFrdUTDyKX7mSWFFxNSQxXbWRm7c4pKr9jbTiUJyM/4bC9fHw==",
+      "dependencies": {
+        "preact": "^10.17.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.0.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -18555,6 +18565,15 @@
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
       "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==",
       "license": "ISC"
+    },
+    "node_modules/preact": {
+      "version": "10.22.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.22.1.tgz",
+      "integrity": "sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",
     "@deck.gl/core": "^9.0.20",
-    "@deck.gl/geo-layers": "^9.0.19",
-    "@deck.gl/react": "^9.0.19",
+    "@deck.gl/geo-layers": "^9.0.20",
+    "@deck.gl/react": "^9.0.20",
+    "@deck.gl/widgets": "^9.0.20",
     "@emotion/react": "^11.11.3",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.11.0",


### PR DESCRIPTION
- Map has controls that allow the user to adjust zoom and resetting bearing
- Uses new [ZoomWidget](https://deck.gl/docs/api-reference/widgets/zoom-widget) and [CompassWidget](https://deck.gl/docs/api-reference/widgets/compass-widget) classes from Deck.gl. Due to a https://github.com/visgl/deck.gl/issues/8877 in Deck that was recently patched, this Issue requires upgrading Deck dependencies to most recent version 9.0.20. Note that the controls rendered by Deck widgets will look different than those shown in [figma](https://www.figma.com/design/LYHHoPop9l0jpEivk5CFzJ/Capital-Projects-Portal?node-id=337-3772&t=KGRjmeAKGkxSYIRL-0). That is because those designs use the components from react-map-gl. For this Issue, the default styling of the Deck widgets is sufficient.
- Controls should be anchored to top-right on mobile screen sizes and bottom-right on desktop
- Logo should appear as in figma

Completes #33 

With regard to logo placement - there is different placement across the mobile designs, so I experimented with different placement.
- Bottom: needs to be either hidden behind the button which shows on page load; or above the button, which would require we move the logo when the button is hidden or else it looks weird.  None of these options are great.
- Top-right: forces the map controls down slightly, and also has the logo appearing over shapes that are the same color
- Top-left: requires no movement of other elements or logo itself, default map view will always have logo appearing above NJ so there will not be any problems with the orange on orange.  This is the one I went with.
