### PR TITLE
Pin to node 20 & Release to QA branch

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,16 +1,13 @@
-name: 🎭 Deploy to staging
+name: 🕵️ Deploy to quality assurance
 
-on:
-    push:
-        branches:
-            - main
+on: workflow_dispatch
 
 jobs:
     deploy:
         name: 🚀 Deploy
         environment:
-            name: staging-cp-map
-            url: https://staging-capitalplanning.nycplanningdigital.com
+            name: qa-cp-map
+            url: https://qa-capitalplanning.nycplanningdigital.com
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "vitest": "^1.3.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": "20.x"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vitest": "^1.3.1"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": "20.x"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
## First ticket
Pin engine to Node 20
    
Ensure that development and release environments all use the same major node version (20)
    
closes #54

## Second ticket
Configure QA deployment
    
Create an environment for quality assurance.
Feature branches can be manually deployed for review.
    
closes #50