### PR TITLE
Update pointerEvents style selector to only apply to direct children

### DIFF
--- a/app/components/Overlay.tsx
+++ b/app/components/Overlay.tsx
@@ -17,7 +17,7 @@ export const Overlay = ({ children }: OverlayProps) => {
       align={{ base: "center", lg: "flex-start" }}
       pointerEvents={"none"}
       sx={{
-        "*": {
+        "> *": {
           pointerEvents: "auto",
         },
       }}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -250,6 +250,11 @@ export default function App() {
                   width={"full"}
                   gap={3}
                   pointerEvents={"none"}
+                  sx={{
+                    "> *": {
+                      pointerEvents: "auto",
+                    },
+                  }}
                 >
                   <Outlet />
                   <Box>


### PR DESCRIPTION
Closes #72 

This PR changes the selector for a couple `pointerEvents: "auto"` styles from `*` to `> *`. This fixes a bug where clicking the down chevron icon on `<Select>` components wouldn't work. By making this selector more specific, the various panels rendered on top of the map work as intended without this style applying to things _within_ the panels.