### PR TITLE
Fix final end of projects page in mobile views

### DIFF
--- a/app/components/CapitalProjectsList/CapitalProjectsDrawer.tsx
+++ b/app/components/CapitalProjectsList/CapitalProjectsDrawer.tsx
@@ -28,6 +28,7 @@ export const CapitalProjectsDrawer = ({
       borderTopRightRadius={"base"}
       gap={4}
       position={{ base: "fixed", lg: "static" }}
+      width={"full"}
     >
       <MobilePanelResizeBar
         isExpanded={isExpanded}


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/ae-cp-map/issues/90

The number of total projects per district changed so try CCD 9 instead of CCD 22 to test. 