### PR TITLE
Set title for site in root

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -123,7 +123,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
 function Document({
   children,
-  title = "App title",
+  title = "Capital Projects",
 }: {
   children: React.ReactNode;
   title?: string;


### PR DESCRIPTION
This PR changes `root.tsx` to set the "title" for the site to something other than the default "App title".