### PR TITLE
125 Zooming at max zoom pans map

### DIFF
--- a/app/components/atlas.client.tsx
+++ b/app/components/atlas.client.tsx
@@ -15,8 +15,8 @@ import {
 } from "./layers";
 import type { MapView, MapViewState } from "@deck.gl/core";
 
-const MAX_ZOOM = 20;
-const MIN_ZOOM = 10;
+export const MAX_ZOOM = 20;
+export const MIN_ZOOM = 10;
 
 const INITIAL_VIEW_STATE = {
   longitude: -74.0008,

--- a/app/components/atlas.client.tsx
+++ b/app/components/atlas.client.tsx
@@ -15,16 +15,18 @@ import {
 } from "./layers";
 import type { MapView, MapViewState } from "@deck.gl/core";
 
+const MAX_ZOOM = 20;
+const MIN_ZOOM = 10;
+
 const INITIAL_VIEW_STATE = {
   longitude: -74.0008,
   latitude: 40.7018,
   zoom: 10,
   bearing: 0,
   pitch: 0,
+  maxZoom: MAX_ZOOM,
+  minZoom: MIN_ZOOM,
 };
-
-const MAX_ZOOM = 20;
-const MIN_ZOOM = 10;
 
 export function Atlas() {
   const capitalProjectsLayer = useCapitalProjectsLayer();

--- a/app/components/atlas.client.tsx
+++ b/app/components/atlas.client.tsx
@@ -24,8 +24,6 @@ const INITIAL_VIEW_STATE = {
   zoom: 10,
   bearing: 0,
   pitch: 0,
-  maxZoom: MAX_ZOOM,
-  minZoom: MIN_ZOOM,
 };
 
 export function Atlas() {
@@ -62,11 +60,14 @@ export function Atlas() {
       onViewStateChange={({ viewState: newViewState }) => {
         setViewState({
           ...newViewState,
-          longitude: Math.min(
-            -73.6311,
-            Math.max(-74.3308, newViewState.longitude),
-          ),
-          latitude: Math.min(41.103, Math.max(40.2989, newViewState.latitude)),
+          longitude:
+            newViewState.zoom < MIN_ZOOM
+              ? viewState.longitude
+              : Math.min(-73.6311, Math.max(-74.3308, newViewState.longitude)),
+          latitude:
+            newViewState.zoom < MIN_ZOOM
+              ? viewState.latitude
+              : Math.min(41.103, Math.max(40.2989, newViewState.latitude)),
           bearing: newViewState.bearing,
           pitch: 0,
           zoom: Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, newViewState.zoom)),

--- a/app/extensions/FlyToGeoJsonExtension.ts
+++ b/app/extensions/FlyToGeoJsonExtension.ts
@@ -43,8 +43,6 @@ export class FlyToGeoJsonExtension extends LayerExtension {
         zoom: zoom,
         transitionDuration: 750,
         transitionInterpolator: new FlyToInterpolator(),
-        maxZoom: MAX_ZOOM,
-        minZoom: MIN_ZOOM,
       };
       deckInstance.props.onViewStateChange({
         viewState: newViewState,

--- a/app/extensions/FlyToGeoJsonExtension.ts
+++ b/app/extensions/FlyToGeoJsonExtension.ts
@@ -7,6 +7,7 @@ import {
 } from "@deck.gl/core";
 import { bbox } from "@turf/bbox";
 import { Geometry } from "geojson";
+import { MIN_ZOOM, MAX_ZOOM } from "../components/atlas.client";
 
 export class FlyToGeoJsonExtension extends LayerExtension {
   updateState(
@@ -42,6 +43,8 @@ export class FlyToGeoJsonExtension extends LayerExtension {
         zoom: zoom,
         transitionDuration: 750,
         transitionInterpolator: new FlyToInterpolator(),
+        maxZoom: MAX_ZOOM,
+        minZoom: MIN_ZOOM,
       };
       deckInstance.props.onViewStateChange({
         viewState: newViewState,


### PR DESCRIPTION
Fixed issue where after fully zooming out using the mouse scroller, any more scrolls move the map to the left/down.

The default minZoom for the MapViewState is 0, so the map was attempting to zoom out, only to be manually corrected in the onViewStateChange.  By setting the minZoom to be MIN_ZOOM in the initial state, we override the default and make the zoom stop before the manual correction in onViewStateChange would otherwise kick in.

Closes #125 