### PR TITLE
Fix panning at max zoom bug with onViewStateChange logic instead of max and min zoom

### DIFF
--- a/app/components/atlas.client.tsx
+++ b/app/components/atlas.client.tsx
@@ -24,8 +24,6 @@ const INITIAL_VIEW_STATE = {
   zoom: 10,
   bearing: 0,
   pitch: 0,
-  maxZoom: MAX_ZOOM,
-  minZoom: MIN_ZOOM,
 };
 
 export function Atlas() {
@@ -62,11 +60,14 @@ export function Atlas() {
       onViewStateChange={({ viewState: newViewState }) => {
         setViewState({
           ...newViewState,
-          longitude: Math.min(
-            -73.6311,
-            Math.max(-74.3308, newViewState.longitude),
-          ),
-          latitude: Math.min(41.103, Math.max(40.2989, newViewState.latitude)),
+          longitude:
+            newViewState.zoom < MIN_ZOOM
+              ? viewState.longitude
+              : Math.min(-73.6311, Math.max(-74.3308, newViewState.longitude)),
+          latitude:
+            newViewState.zoom < MIN_ZOOM
+              ? viewState.latitude
+              : Math.min(41.103, Math.max(40.2989, newViewState.latitude)),
           bearing: newViewState.bearing,
           pitch: 0,
           zoom: Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, newViewState.zoom)),

--- a/app/extensions/FlyToGeoJsonExtension.ts
+++ b/app/extensions/FlyToGeoJsonExtension.ts
@@ -43,8 +43,6 @@ export class FlyToGeoJsonExtension extends LayerExtension {
         zoom: zoom,
         transitionDuration: 750,
         transitionInterpolator: new FlyToInterpolator(),
-        maxZoom: MAX_ZOOM,
-        minZoom: MIN_ZOOM,
       };
       deckInstance.props.onViewStateChange({
         viewState: newViewState,


### PR DESCRIPTION
@dhochbaum-dcp  This PR builds on the changes in `125/tm-zoom-pan` to hopefully fix this issue in a way that plays nicer with how we're already using Deck. The fix already on that branch helped me realize the bug was because the map also _pans_ toward your cursor when you zoom. We already implement our own min and max zoom in `onViewStateChange`, based on Deck's [documentation](https://deck.gl/docs/developer-guide/interactivity#add-constraints-to-view-state), but we don't account for the latitude and longitude changing when zooming beyond the minimum zoom level. This change is meant to address that, while sticking with managing the min/max zoom ourselves, instead of mixing managed and unmanaged versions. This also means we only have to account for it in one place, so we don't need the change in `FlyToGeoJsonExtension`.