### PR TITLE
Bugfix: overlapped projects are unselectable

### DIFF
--- a/app/components/layers/useCapitalProjectBudgetedGeoJsonLayer.client.tsx
+++ b/app/components/layers/useCapitalProjectBudgetedGeoJsonLayer.client.tsx
@@ -12,7 +12,7 @@ export function useCapitalProjectBudgetedGeoJsonLayer() {
       managingCode === undefined || capitalProjectId === undefined
         ? []
         : `${import.meta.env.VITE_ZONING_API_URL}/api/capital-projects/${managingCode}/${capitalProjectId}/geojson`,
-    pickable: true,
+    pickable: false,
     getFillColor: ({ id }) => {
       switch (id) {
         case `${managingCode}${capitalProjectId}`:


### PR DESCRIPTION
Turn off pickability of selected project layer,
letting event bubble to projects layer

closes #136