### PR TITLE
144 Adblock Breaks Features

### DIFF
--- a/app/utils/analytics.js
+++ b/app/utils/analytics.js
@@ -1,19 +1,21 @@
 export function analytics(eventData) {
-  if (eventData.value) {
-    window._paq.push([
-      "trackEvent",
-      eventData.category,
-      eventData.action,
-      eventData.name,
-      eventData.value,
-    ]);
-  } else {
-    window._paq.push([
-      "trackEvent",
-      eventData.category,
-      eventData.action,
-      eventData.name,
-    ]);
+  if(window._paq) {
+    if (eventData.value) {
+      window._paq.push([
+        "trackEvent",
+        eventData.category,
+        eventData.action,
+        eventData.name,
+        eventData.value,
+      ]);
+    } else {
+      window._paq.push([
+        "trackEvent",
+        eventData.category,
+        eventData.action,
+        eventData.name,
+      ]);
+    }
   }
 }
 

--- a/app/utils/analytics.js
+++ b/app/utils/analytics.js
@@ -1,4 +1,5 @@
 export function analytics(eventData) {
+  // window._paq is what Matomo uses to track data.
   if(window._paq) {
     if (eventData.value) {
       window._paq.push([


### PR DESCRIPTION
The issue was caused by ad blocking extensions preventing Matomo from loading, causing the analytics function to fail.  This adds a simple check for window._paq to make sure if adblock is preventing Matomo from loading, it doesn't break features.

Closes #152 