### PR TITLE
158 Add agency budget (Project Type) filter functionality to front end

### DIFF
--- a/app/components/AdminDropdown/AgencyDropdown.test.tsx
+++ b/app/components/AdminDropdown/AgencyDropdown.test.tsx
@@ -39,8 +39,6 @@ describe("AgencyDropdown", () => {
         firstAgencyInitials,
       ),
     );
-    expect(onSelectValueChange).toHaveBeenCalledWith({
-      managingAgency: firstAgencyInitials,
-    });
+    expect(onSelectValueChange).toHaveBeenCalledWith(firstAgencyInitials);
   });
 });

--- a/app/components/AdminDropdown/ProjectTypeDropdown.test.tsx
+++ b/app/components/AdminDropdown/ProjectTypeDropdown.test.tsx
@@ -1,0 +1,44 @@
+import { AgencyBudget, createAgencyBudget } from "~/gen";
+import { ProjectTypeDropdown } from "./ProjectTypeDropdown";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { act } from "react";
+
+describe("ProjectTypeDropdown", () => {
+  let agencyBudgets: Array<AgencyBudget> = [];
+  beforeAll(() => {
+    agencyBudgets = Array.from(Array(1), () => createAgencyBudget());
+  });
+
+  it("should render project type form details and options", () => {
+    const onSelectValueChange = vi.fn();
+    render(
+      <ProjectTypeDropdown
+        onSelectValueChange={onSelectValueChange}
+        projectTypes={agencyBudgets}
+      />,
+    );
+    expect(screen.getByLabelText("Project Type")).toBeInTheDocument();
+    const firstAgencyBudgetLabel = `${agencyBudgets[0].type}`;
+    expect(screen.getByText(firstAgencyBudgetLabel)).toBeInTheDocument();
+  });
+
+  it("should set search params when changing the project type", async () => {
+    const onSelectValueChange = vi.fn();
+    const firstAgencyBudgetCode = agencyBudgets[0].code;
+    render(
+      <ProjectTypeDropdown
+        onSelectValueChange={onSelectValueChange}
+        projectTypes={agencyBudgets}
+      />,
+    );
+
+    await act(() =>
+      userEvent.selectOptions(
+        screen.getByRole("combobox"),
+        firstAgencyBudgetCode,
+      ),
+    );
+    expect(onSelectValueChange).toHaveBeenCalledWith(firstAgencyBudgetCode);
+  });
+});

--- a/app/components/AdminDropdown/ProjectTypeDropdown.tsx
+++ b/app/components/AdminDropdown/ProjectTypeDropdown.tsx
@@ -1,0 +1,44 @@
+import { AgencyBudget } from "~/gen";
+import { AdminDropdownProps, AdminDropdown } from ".";
+import { AgencyBudgetType } from "../../utils/types";
+import { analytics } from "../../utils/analytics";
+
+export interface ProjectTypeDropdownProps
+  extends Pick<AdminDropdownProps, "selectValue"> {
+  projectTypes: Array<AgencyBudget> | null;
+  onSelectValueChange?: (value: null | string) => void;
+}
+export function ProjectTypeDropdown({
+  selectValue,
+  projectTypes,
+  onSelectValueChange = () => null,
+}: ProjectTypeDropdownProps) {
+  const updateProjectType = (nextProjectType: AgencyBudgetType) => {
+    analytics({
+      category: "Dropdown Menu",
+      action: "Change Project Type",
+      name: nextProjectType,
+    });
+
+    onSelectValueChange(nextProjectType);
+  };
+
+  const projectTypeOptions = projectTypes
+    ?.sort((a, b) => a.type.localeCompare(b.type))
+    .map((projectType) => (
+      <option key={projectType.type} value={projectType.code}>
+        {projectType.type}
+      </option>
+    ));
+  return (
+    <AdminDropdown
+      formId="projectType"
+      formLabel="Project Type"
+      isSelectDisabled={projectTypes === null}
+      selectValue={selectValue}
+      onSelectValueChange={updateProjectType}
+    >
+      {projectTypeOptions}
+    </AdminDropdown>
+  );
+}

--- a/app/components/AdminDropdown/index.tsx
+++ b/app/components/AdminDropdown/index.tsx
@@ -12,6 +12,7 @@ export { DistrictTypeDropdown } from "./DistrictTypeDropdown";
 export { CommunityDistrictDropdown } from "./CommunityDistrictDropdown";
 export { CityCouncilDistrictDropdown } from "./CityCouncilDistrictDropdown";
 export { AgencyDropdown } from "./AgencyDropdown";
+export { ProjectTypeDropdown } from "./ProjectTypeDropdown";
 
 export interface AdminDropdownProps {
   formId: string;

--- a/app/components/CapitalProjectsList/CapitalProjectsDrawer.test.tsx
+++ b/app/components/CapitalProjectsList/CapitalProjectsDrawer.test.tsx
@@ -11,6 +11,7 @@ describe("CapitalProjectsDrawer", () => {
           capitalProjects={[]}
           district={district}
           agencies={[]}
+          agencyBudgets={[]}
         >
           <></>
         </CapitalProjectsDrawer>
@@ -27,6 +28,7 @@ describe("CapitalProjectsDrawer", () => {
           capitalProjects={[]}
           district={district}
           agencies={[]}
+          agencyBudgets={[]}
         >
           <></>
         </CapitalProjectsDrawer>
@@ -43,6 +45,7 @@ describe("CapitalProjectsDrawer", () => {
           capitalProjects={[]}
           district={district}
           agencies={[]}
+          agencyBudgets={[]}
         >
           <></>
         </CapitalProjectsDrawer>

--- a/app/components/CapitalProjectsList/CapitalProjectsDrawer.tsx
+++ b/app/components/CapitalProjectsList/CapitalProjectsDrawer.tsx
@@ -1,5 +1,5 @@
 import { Flex, Heading } from "@nycplanning/streetscape";
-import { Agency, CapitalProject } from "~/gen";
+import { Agency, CapitalProject, AgencyBudget } from "~/gen";
 import { CapitalProjectsList } from "./CapitalProjectsList";
 import { useState } from "react";
 import { MobilePanelResizeBar } from "../MobilePanelResizeBar";
@@ -8,6 +8,7 @@ export interface CapitalProjectsDrawerProps {
   capitalProjects: Array<CapitalProject>;
   district: string;
   agencies: Agency[];
+  agencyBudgets: AgencyBudget[];
   children: React.ReactNode;
 }
 

--- a/app/components/CapitalProjectsList/CapitalProjectsPanel.test.tsx
+++ b/app/components/CapitalProjectsList/CapitalProjectsPanel.test.tsx
@@ -7,6 +7,7 @@ describe("CapitalProjectsPanel", () => {
       <CapitalProjectsPanel
         capitalProjects={[]}
         agencies={[]}
+        agencyBudgets={[]}
         district="Community District"
       >
         <></>

--- a/app/components/CapitalProjectsList/CapitalProjectsPanel.tsx
+++ b/app/components/CapitalProjectsList/CapitalProjectsPanel.tsx
@@ -28,6 +28,7 @@ export function CapitalProjectsPanel(props: CapitalProjectsPanelProps) {
         <CapitalProjectsDrawer
           capitalProjects={props.capitalProjects}
           agencies={props.agencies}
+          agencyBudgets={props.agencyBudgets}
           district={props.district}
         >
           {props.children}

--- a/app/gen/axios/findAgencyBudgets.ts
+++ b/app/gen/axios/findAgencyBudgets.ts
@@ -4,14 +4,14 @@ import type { FindAgencyBudgetsQueryResponse } from "../types/FindAgencyBudgets"
 
 /**
  * @summary Find agency budgets
- * @link /agencyBugdets
+ * @link /agency-budgets
  */
 export async function findAgencyBudgets(
   options: Partial<Parameters<typeof client>[0]> = {},
 ): Promise<ResponseConfig<FindAgencyBudgetsQueryResponse>["data"]> {
   const res = await client<FindAgencyBudgetsQueryResponse>({
     method: "get",
-    url: `/agencyBugdets`,
+    url: `/agency-budgets`,
     baseURL: "https://zoning.planningdigital.com/api",
     ...options,
   });

--- a/app/gen/axios/operations.ts
+++ b/app/gen/axios/operations.ts
@@ -4,7 +4,7 @@ export const operations = {
     method: "get",
   },
   findAgencyBudgets: {
-    path: "/agencyBugdets",
+    path: "/agency-budgets",
     method: "get",
   },
   findBoroughs: {

--- a/app/gen/mocks/createCapitalProjectPage.ts
+++ b/app/gen/mocks/createCapitalProjectPage.ts
@@ -11,5 +11,6 @@ export function createCapitalProjectPage(
     capitalProjects: faker.helpers.arrayElements([
       createCapitalProject(),
     ]) as any,
+    totalProjects: faker.number.int(),
   });
 }

--- a/app/gen/mocks/createFindAgencies.ts
+++ b/app/gen/mocks/createFindAgencies.ts
@@ -10,10 +10,13 @@ import type {
 } from "../types/FindAgencies";
 
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export function createFindAgencies200(): NonNullable<FindAgencies200> {
-  return { agencies: faker.helpers.arrayElements([createAgency()]) as any };
+  return {
+    agencies: faker.helpers.arrayElements([createAgency()]) as any,
+    order: faker.string.alpha(),
+  };
 }
 
 /**
@@ -31,8 +34,11 @@ export function createFindAgencies500(): NonNullable<FindAgencies500> {
 }
 
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export function createFindAgenciesQueryResponse(): NonNullable<FindAgenciesQueryResponse> {
-  return { agencies: faker.helpers.arrayElements([createAgency()]) as any };
+  return {
+    agencies: faker.helpers.arrayElements([createAgency()]) as any,
+    order: faker.string.alpha(),
+  };
 }

--- a/app/gen/mocks/createFindCapitalProjects.ts
+++ b/app/gen/mocks/createFindCapitalProjects.ts
@@ -21,6 +21,15 @@ export function createFindCapitalProjectsQueryParams(): NonNullable<FindCapitalP
       new RandExp("^([0-9]{1,2})$").gen(),
     ]),
     managingAgency: faker.string.alpha(),
+    agencyBudget: faker.string.alpha(),
+    commitmentsTotalMin: faker.helpers.arrayElement<any>([
+      faker.string.alpha(),
+      new RandExp("^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\\.[0-9]{2})?$").gen(),
+    ]),
+    commitmentsTotalMax: faker.helpers.arrayElement<any>([
+      faker.string.alpha(),
+      new RandExp("^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\\.[0-9]{2})?$").gen(),
+    ]),
     limit: faker.number.int(),
     offset: faker.number.int(),
   };

--- a/app/gen/mocks/createFindCapitalProjectsByBoroughIdCommunityDistrictId.ts
+++ b/app/gen/mocks/createFindCapitalProjectsByBoroughIdCommunityDistrictId.ts
@@ -7,7 +7,6 @@ import type {
   FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams,
   FindCapitalProjectsByBoroughIdCommunityDistrictId200,
   FindCapitalProjectsByBoroughIdCommunityDistrictId400,
-  FindCapitalProjectsByBoroughIdCommunityDistrictId404,
   FindCapitalProjectsByBoroughIdCommunityDistrictId500,
   FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponse,
 } from "../types/FindCapitalProjectsByBoroughIdCommunityDistrictId";
@@ -40,13 +39,6 @@ export function createFindCapitalProjectsByBoroughIdCommunityDistrictId200(): No
  * @description Invalid client request
  */
 export function createFindCapitalProjectsByBoroughIdCommunityDistrictId400(): NonNullable<FindCapitalProjectsByBoroughIdCommunityDistrictId400> {
-  return createError();
-}
-
-/**
- * @description Requested resource does not exist or is not available
- */
-export function createFindCapitalProjectsByBoroughIdCommunityDistrictId404(): NonNullable<FindCapitalProjectsByBoroughIdCommunityDistrictId404> {
   return createError();
 }
 

--- a/app/gen/mocks/createFindCapitalProjectsByCityCouncilId.ts
+++ b/app/gen/mocks/createFindCapitalProjectsByCityCouncilId.ts
@@ -7,7 +7,6 @@ import type {
   FindCapitalProjectsByCityCouncilIdQueryParams,
   FindCapitalProjectsByCityCouncilId200,
   FindCapitalProjectsByCityCouncilId400,
-  FindCapitalProjectsByCityCouncilId404,
   FindCapitalProjectsByCityCouncilId500,
   FindCapitalProjectsByCityCouncilIdQueryResponse,
 } from "../types/FindCapitalProjectsByCityCouncilId";
@@ -36,13 +35,6 @@ export function createFindCapitalProjectsByCityCouncilId200(): NonNullable<FindC
  * @description Invalid client request
  */
 export function createFindCapitalProjectsByCityCouncilId400(): NonNullable<FindCapitalProjectsByCityCouncilId400> {
-  return createError();
-}
-
-/**
- * @description Requested resource does not exist or is not available
- */
-export function createFindCapitalProjectsByCityCouncilId404(): NonNullable<FindCapitalProjectsByCityCouncilId404> {
   return createError();
 }
 

--- a/app/gen/mocks/findAgencyBudgetsHandler.ts
+++ b/app/gen/mocks/findAgencyBudgetsHandler.ts
@@ -2,7 +2,7 @@ import { http } from "msw";
 import { createFindAgencyBudgetsQueryResponse } from "./createFindAgencyBudgets";
 
 export const findAgencyBudgetsHandler = http.get(
-  "*/agencyBugdets",
+  "*/agency-budgets",
   function handler(info) {
     return new Response(
       JSON.stringify(createFindAgencyBudgetsQueryResponse()),

--- a/app/gen/types/CapitalProjectPage.ts
+++ b/app/gen/types/CapitalProjectPage.ts
@@ -6,4 +6,9 @@ export type CapitalProjectPage = Page & {
    * @type array
    */
   capitalProjects: CapitalProject[];
+  /**
+   * @description The total number of results matching the query parameters.
+   * @type integer
+   */
+  totalProjects: number;
 };

--- a/app/gen/types/FindAgencies.ts
+++ b/app/gen/types/FindAgencies.ts
@@ -2,13 +2,19 @@ import type { Agency } from "./Agency";
 import type { Error } from "./Error";
 
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export type FindAgencies200 = {
   /**
+   * @description An list of agencies sorted alphabetically by the agency initials.\n
    * @type array
    */
   agencies: Agency[];
+  /**
+   * @description The criteria used to sort the results using the agency initials in ascending order.
+   * @type string
+   */
+  order: string;
 };
 /**
  * @description Invalid client request
@@ -19,13 +25,19 @@ export type FindAgencies400 = Error;
  */
 export type FindAgencies500 = Error;
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export type FindAgenciesQueryResponse = {
   /**
+   * @description An list of agencies sorted alphabetically by the agency initials.\n
    * @type array
    */
   agencies: Agency[];
+  /**
+   * @description The criteria used to sort the results using the agency initials in ascending order.
+   * @type string
+   */
+  order: string;
 };
 export type FindAgenciesQuery = {
   Response: FindAgenciesQueryResponse;

--- a/app/gen/types/FindCapitalProjects.ts
+++ b/app/gen/types/FindCapitalProjects.ts
@@ -18,6 +18,21 @@ export type FindCapitalProjectsQueryParams = {
    */
   managingAgency?: string;
   /**
+   * @description The two character alphabetic string containing the letters used to refer to the agency budget code.
+   * @type string | undefined
+   */
+  agencyBudget?: string;
+  /**
+   * @description Minimum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.
+   * @type string | undefined
+   */
+  commitmentsTotalMin?: string;
+  /**
+   * @description Maximum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.
+   * @type string | undefined
+   */
+  commitmentsTotalMax?: string;
+  /**
    * @description The maximum number of results to be returned in each response. The default value is 20. It must be between 1 and 100, inclusive.
    * @type integer | undefined
    */

--- a/app/gen/types/FindCapitalProjectsByBoroughIdCommunityDistrictId.ts
+++ b/app/gen/types/FindCapitalProjectsByBoroughIdCommunityDistrictId.ts
@@ -35,10 +35,6 @@ export type FindCapitalProjectsByBoroughIdCommunityDistrictId200 =
  */
 export type FindCapitalProjectsByBoroughIdCommunityDistrictId400 = Error;
 /**
- * @description Requested resource does not exist or is not available
- */
-export type FindCapitalProjectsByBoroughIdCommunityDistrictId404 = Error;
-/**
  * @description Server side error
  */
 export type FindCapitalProjectsByBoroughIdCommunityDistrictId500 = Error;
@@ -53,6 +49,5 @@ export type FindCapitalProjectsByBoroughIdCommunityDistrictIdQuery = {
   QueryParams: FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams;
   Errors:
     | FindCapitalProjectsByBoroughIdCommunityDistrictId400
-    | FindCapitalProjectsByBoroughIdCommunityDistrictId404
     | FindCapitalProjectsByBoroughIdCommunityDistrictId500;
 };

--- a/app/gen/types/FindCapitalProjectsByCityCouncilId.ts
+++ b/app/gen/types/FindCapitalProjectsByCityCouncilId.ts
@@ -29,10 +29,6 @@ export type FindCapitalProjectsByCityCouncilId200 = CapitalProjectPage;
  */
 export type FindCapitalProjectsByCityCouncilId400 = Error;
 /**
- * @description Requested resource does not exist or is not available
- */
-export type FindCapitalProjectsByCityCouncilId404 = Error;
-/**
  * @description Server side error
  */
 export type FindCapitalProjectsByCityCouncilId500 = Error;
@@ -47,6 +43,5 @@ export type FindCapitalProjectsByCityCouncilIdQuery = {
   QueryParams: FindCapitalProjectsByCityCouncilIdQueryParams;
   Errors:
     | FindCapitalProjectsByCityCouncilId400
-    | FindCapitalProjectsByCityCouncilId404
     | FindCapitalProjectsByCityCouncilId500;
 };

--- a/app/gen/zod/capitalProjectPageSchema.ts
+++ b/app/gen/zod/capitalProjectPageSchema.ts
@@ -5,5 +5,12 @@ import { z } from "zod";
 export const capitalProjectPageSchema = z
   .lazy(() => pageSchema)
   .and(
-    z.object({ capitalProjects: z.array(z.lazy(() => capitalProjectSchema)) }),
+    z.object({
+      capitalProjects: z.array(z.lazy(() => capitalProjectSchema)),
+      totalProjects: z
+        .number()
+        .int()
+        .min(0)
+        .describe("The total number of results matching the query parameters."),
+    }),
   );

--- a/app/gen/zod/findAgenciesSchema.ts
+++ b/app/gen/zod/findAgenciesSchema.ts
@@ -3,10 +3,19 @@ import { agencySchema } from "./agencySchema";
 import { errorSchema } from "./errorSchema";
 
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export const findAgencies200Schema = z.object({
-  agencies: z.array(z.lazy(() => agencySchema)),
+  agencies: z
+    .array(z.lazy(() => agencySchema))
+    .describe(
+      "An list of agencies sorted alphabetically by the agency initials.\n",
+    ),
+  order: z
+    .string()
+    .describe(
+      "The criteria used to sort the results using the agency initials in ascending order.",
+    ),
 });
 /**
  * @description Invalid client request
@@ -17,8 +26,17 @@ export const findAgencies400Schema = z.lazy(() => errorSchema);
  */
 export const findAgencies500Schema = z.lazy(() => errorSchema);
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export const findAgenciesQueryResponseSchema = z.object({
-  agencies: z.array(z.lazy(() => agencySchema)),
+  agencies: z
+    .array(z.lazy(() => agencySchema))
+    .describe(
+      "An list of agencies sorted alphabetically by the agency initials.\n",
+    ),
+  order: z
+    .string()
+    .describe(
+      "The criteria used to sort the results using the agency initials in ascending order.",
+    ),
 });

--- a/app/gen/zod/findCapitalProjectsByBoroughIdCommunityDistrictIdSchema.ts
+++ b/app/gen/zod/findCapitalProjectsByBoroughIdCommunityDistrictIdSchema.ts
@@ -51,11 +51,6 @@ export const findCapitalProjectsByBoroughIdCommunityDistrictId200Schema =
 export const findCapitalProjectsByBoroughIdCommunityDistrictId400Schema =
   z.lazy(() => errorSchema);
 /**
- * @description Requested resource does not exist or is not available
- */
-export const findCapitalProjectsByBoroughIdCommunityDistrictId404Schema =
-  z.lazy(() => errorSchema);
-/**
  * @description Server side error
  */
 export const findCapitalProjectsByBoroughIdCommunityDistrictId500Schema =

--- a/app/gen/zod/findCapitalProjectsByCityCouncilIdSchema.ts
+++ b/app/gen/zod/findCapitalProjectsByCityCouncilIdSchema.ts
@@ -43,12 +43,6 @@ export const findCapitalProjectsByCityCouncilId400Schema = z.lazy(
   () => errorSchema,
 );
 /**
- * @description Requested resource does not exist or is not available
- */
-export const findCapitalProjectsByCityCouncilId404Schema = z.lazy(
-  () => errorSchema,
-);
-/**
  * @description Server side error
  */
 export const findCapitalProjectsByCityCouncilId500Schema = z.lazy(

--- a/app/gen/zod/findCapitalProjectsSchema.ts
+++ b/app/gen/zod/findCapitalProjectsSchema.ts
@@ -22,6 +22,26 @@ export const findCapitalProjectsQueryParamsSchema = z
       .string()
       .describe("The acronym of the managing agency to filter the projects by.")
       .optional(),
+    agencyBudget: z
+      .string()
+      .describe(
+        "The two character alphabetic string containing the letters used to refer to the agency budget code.",
+      )
+      .optional(),
+    commitmentsTotalMin: z
+      .string()
+      .regex(new RegExp("^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\\.[0-9]{2})?$"))
+      .describe(
+        "Minimum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.",
+      )
+      .optional(),
+    commitmentsTotalMax: z
+      .string()
+      .regex(new RegExp("^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\\.[0-9]{2})?$"))
+      .describe(
+        "Maximum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.",
+      )
+      .optional(),
     limit: z
       .number()
       .int()

--- a/app/gen/zod/operations.ts
+++ b/app/gen/zod/operations.ts
@@ -30,7 +30,6 @@ import {
 import {
   findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
   findCapitalProjectsByBoroughIdCommunityDistrictId400Schema,
-  findCapitalProjectsByBoroughIdCommunityDistrictId404Schema,
   findCapitalProjectsByBoroughIdCommunityDistrictId500Schema,
   findCapitalProjectsByBoroughIdCommunityDistrictIdPathParamsSchema,
   findCapitalProjectsByBoroughIdCommunityDistrictIdQueryParamsSchema,
@@ -100,7 +99,6 @@ import {
 import {
   findCapitalProjectsByCityCouncilIdQueryResponseSchema,
   findCapitalProjectsByCityCouncilId400Schema,
-  findCapitalProjectsByCityCouncilId404Schema,
   findCapitalProjectsByCityCouncilId500Schema,
   findCapitalProjectsByCityCouncilIdPathParamsSchema,
   findCapitalProjectsByCityCouncilIdQueryParamsSchema,
@@ -294,14 +292,12 @@ export const operations = {
     responses: {
       200: findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
       400: findCapitalProjectsByBoroughIdCommunityDistrictId400Schema,
-      404: findCapitalProjectsByBoroughIdCommunityDistrictId404Schema,
       500: findCapitalProjectsByBoroughIdCommunityDistrictId500Schema,
       default:
         findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
     },
     errors: {
       400: findCapitalProjectsByBoroughIdCommunityDistrictId400Schema,
-      404: findCapitalProjectsByBoroughIdCommunityDistrictId404Schema,
       500: findCapitalProjectsByBoroughIdCommunityDistrictId500Schema,
     },
   },
@@ -509,13 +505,11 @@ export const operations = {
     responses: {
       200: findCapitalProjectsByCityCouncilIdQueryResponseSchema,
       400: findCapitalProjectsByCityCouncilId400Schema,
-      404: findCapitalProjectsByCityCouncilId404Schema,
       500: findCapitalProjectsByCityCouncilId500Schema,
       default: findCapitalProjectsByCityCouncilIdQueryResponseSchema,
     },
     errors: {
       400: findCapitalProjectsByCityCouncilId400Schema,
-      404: findCapitalProjectsByCityCouncilId404Schema,
       500: findCapitalProjectsByCityCouncilId500Schema,
     },
   },
@@ -773,7 +767,7 @@ export const paths = {
   "/agencies": {
     get: operations["findAgencies"],
   },
-  "/agencyBugdets": {
+  "/agency-budgets": {
     get: operations["findAgencyBudgets"],
   },
   "/boroughs": {

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -2,6 +2,7 @@ export type BoroughId = null | string;
 export type DistrictType = null | "cd" | "ccd";
 export type DistrictId = null | string;
 export type ManagingAgencyAcronym = null | string;
+export type AgencyBudgetType = null | string;
 
 export type AdminParams = {
   districtType: DistrictType;
@@ -11,6 +12,7 @@ export type AdminParams = {
 
 export type AttributeParams = {
   managingAgency: ManagingAgencyAcronym;
+  agencyBudget: AgencyBudgetType;
 };
 
 export type SearchParamChanges = Record<


### PR DESCRIPTION
## Acceptance Criteria

- [x] Add new Project Type filter to "Search by Attribute" menu ([designs](https://www.figma.com/design/LYHHoPop9l0jpEivk5CFzJ/Capital-Projects-Portal?node-id=3040-8347&t=6DJJiMHdTYgBMpyB-0))
- [x] Populate dropdown with budget types, using endpoint added in https://github.com/NYCPlanning/ae-zoning-api/issues/401
- [x] When user selects a Project Type and clicks "Search", new `agencyBudget` query param populates in the browser with the corresponding agency budget code. Query param should not populate immediately when a dropdown selection is made
- [x] When user selects a Project Type and clicks "Search", capital projects list updates to only include projects for the given project type and match other filters
- [ ] When user selects a Project Type and clicks "Search", projects displayed on the map update to only include projects for the given project type and match other filters. Map filtering relies on new attribute to be added in https://github.com/NYCPlanning/ae-zoning-api/issues/427

## Depends on 
* https://github.com/NYCPlanning/ae-zoning-api/issues/427
* https://github.com/NYCPlanning/ae-zoning-api/issues/402
* https://github.com/NYCPlanning/ae-zoning-api/issues/401

This branch completes most of what is outlined in #158.  I am not aware of any way to do the map filtering on the front-end.  I'd like to break out the map filtering to a separate issue and merge the rest, to make it easier to work on #159 while we determine what to do with the map filtering.