### PR TITLE
158,159 Add Project Type and Amount (without map updating)

### DIFF
--- a/app/components/AdminDropdown/AgencyDropdown.test.tsx
+++ b/app/components/AdminDropdown/AgencyDropdown.test.tsx
@@ -39,8 +39,6 @@ describe("AgencyDropdown", () => {
         firstAgencyInitials,
       ),
     );
-    expect(onSelectValueChange).toHaveBeenCalledWith({
-      managingAgency: firstAgencyInitials,
-    });
+    expect(onSelectValueChange).toHaveBeenCalledWith(firstAgencyInitials);
   });
 });

--- a/app/components/AdminDropdown/ProjectTypeDropdown.test.tsx
+++ b/app/components/AdminDropdown/ProjectTypeDropdown.test.tsx
@@ -1,0 +1,44 @@
+import { AgencyBudget, createAgencyBudget } from "~/gen";
+import { ProjectTypeDropdown } from "./ProjectTypeDropdown";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { act } from "react";
+
+describe("ProjectTypeDropdown", () => {
+  let agencyBudgets: Array<AgencyBudget> = [];
+  beforeAll(() => {
+    agencyBudgets = Array.from(Array(1), () => createAgencyBudget());
+  });
+
+  it("should render project type form details and options", () => {
+    const onSelectValueChange = vi.fn();
+    render(
+      <ProjectTypeDropdown
+        onSelectValueChange={onSelectValueChange}
+        projectTypes={agencyBudgets}
+      />,
+    );
+    expect(screen.getByLabelText("Project Type")).toBeInTheDocument();
+    const firstAgencyBudgetLabel = `${agencyBudgets[0].type}`;
+    expect(screen.getByText(firstAgencyBudgetLabel)).toBeInTheDocument();
+  });
+
+  it("should set search params when changing the project type", async () => {
+    const onSelectValueChange = vi.fn();
+    const firstAgencyBudgetCode = agencyBudgets[0].code;
+    render(
+      <ProjectTypeDropdown
+        onSelectValueChange={onSelectValueChange}
+        projectTypes={agencyBudgets}
+      />,
+    );
+
+    await act(() =>
+      userEvent.selectOptions(
+        screen.getByRole("combobox"),
+        firstAgencyBudgetCode,
+      ),
+    );
+    expect(onSelectValueChange).toHaveBeenCalledWith(firstAgencyBudgetCode);
+  });
+});

--- a/app/components/AdminDropdown/ProjectTypeDropdown.tsx
+++ b/app/components/AdminDropdown/ProjectTypeDropdown.tsx
@@ -1,0 +1,44 @@
+import { AgencyBudget } from "~/gen";
+import { AdminDropdownProps, AdminDropdown } from ".";
+import { AgencyBudgetType } from "../../utils/types";
+import { analytics } from "../../utils/analytics";
+
+export interface ProjectTypeDropdownProps
+  extends Pick<AdminDropdownProps, "selectValue"> {
+  projectTypes: Array<AgencyBudget> | null;
+  onSelectValueChange?: (value: null | string) => void;
+}
+export function ProjectTypeDropdown({
+  selectValue,
+  projectTypes,
+  onSelectValueChange = () => null,
+}: ProjectTypeDropdownProps) {
+  const updateProjectType = (nextProjectType: AgencyBudgetType) => {
+    analytics({
+      category: "Dropdown Menu",
+      action: "Change Project Type",
+      name: nextProjectType,
+    });
+
+    onSelectValueChange(nextProjectType);
+  };
+
+  const projectTypeOptions = projectTypes
+    ?.sort((a, b) => a.type.localeCompare(b.type))
+    .map((projectType) => (
+      <option key={projectType.type} value={projectType.code}>
+        {projectType.type}
+      </option>
+    ));
+  return (
+    <AdminDropdown
+      formId="projectType"
+      formLabel="Project Type"
+      isSelectDisabled={projectTypes === null}
+      selectValue={selectValue}
+      onSelectValueChange={updateProjectType}
+    >
+      {projectTypeOptions}
+    </AdminDropdown>
+  );
+}

--- a/app/components/AdminDropdown/index.tsx
+++ b/app/components/AdminDropdown/index.tsx
@@ -72,7 +72,7 @@ export function AdminDropdown({
               boxSize={3}
               p={0.5}
               border={"1px solid"}
-              borderRadius={4}
+              borderRadius={16}
             />
           }
         />

--- a/app/components/AdminDropdown/index.tsx
+++ b/app/components/AdminDropdown/index.tsx
@@ -12,6 +12,7 @@ export { DistrictTypeDropdown } from "./DistrictTypeDropdown";
 export { CommunityDistrictDropdown } from "./CommunityDistrictDropdown";
 export { CityCouncilDistrictDropdown } from "./CityCouncilDistrictDropdown";
 export { AgencyDropdown } from "./AgencyDropdown";
+export { ProjectTypeDropdown } from "./ProjectTypeDropdown";
 
 export interface AdminDropdownProps {
   formId: string;

--- a/app/components/CapitalProjectsList/CapitalProjectsDrawer.test.tsx
+++ b/app/components/CapitalProjectsList/CapitalProjectsDrawer.test.tsx
@@ -11,6 +11,7 @@ describe("CapitalProjectsDrawer", () => {
           capitalProjects={[]}
           district={district}
           agencies={[]}
+          agencyBudgets={[]}
         >
           <></>
         </CapitalProjectsDrawer>
@@ -27,6 +28,7 @@ describe("CapitalProjectsDrawer", () => {
           capitalProjects={[]}
           district={district}
           agencies={[]}
+          agencyBudgets={[]}
         >
           <></>
         </CapitalProjectsDrawer>
@@ -43,6 +45,7 @@ describe("CapitalProjectsDrawer", () => {
           capitalProjects={[]}
           district={district}
           agencies={[]}
+          agencyBudgets={[]}
         >
           <></>
         </CapitalProjectsDrawer>

--- a/app/components/CapitalProjectsList/CapitalProjectsDrawer.tsx
+++ b/app/components/CapitalProjectsList/CapitalProjectsDrawer.tsx
@@ -1,5 +1,5 @@
 import { Flex, Heading } from "@nycplanning/streetscape";
-import { Agency, CapitalProject } from "~/gen";
+import { Agency, CapitalProject, AgencyBudget } from "~/gen";
 import { CapitalProjectsList } from "./CapitalProjectsList";
 import { useState } from "react";
 import { MobilePanelResizeBar } from "../MobilePanelResizeBar";
@@ -8,6 +8,7 @@ export interface CapitalProjectsDrawerProps {
   capitalProjects: Array<CapitalProject>;
   district: string;
   agencies: Agency[];
+  agencyBudgets: AgencyBudget[];
   children: React.ReactNode;
 }
 

--- a/app/components/CapitalProjectsList/CapitalProjectsPanel.test.tsx
+++ b/app/components/CapitalProjectsList/CapitalProjectsPanel.test.tsx
@@ -7,6 +7,7 @@ describe("CapitalProjectsPanel", () => {
       <CapitalProjectsPanel
         capitalProjects={[]}
         agencies={[]}
+        agencyBudgets={[]}
         district="Community District"
       >
         <></>

--- a/app/components/CapitalProjectsList/CapitalProjectsPanel.tsx
+++ b/app/components/CapitalProjectsList/CapitalProjectsPanel.tsx
@@ -28,6 +28,7 @@ export function CapitalProjectsPanel(props: CapitalProjectsPanelProps) {
         <CapitalProjectsDrawer
           capitalProjects={props.capitalProjects}
           agencies={props.agencies}
+          agencyBudgets={props.agencyBudgets}
           district={props.district}
         >
           {props.children}

--- a/app/components/ProjectAmountMenu/ProjectAmountMenuInput.test.tsx
+++ b/app/components/ProjectAmountMenu/ProjectAmountMenuInput.test.tsx
@@ -10,6 +10,7 @@ describe("ProjectAmountMenuInput", () => {
     render(
       <ProjectAmountMenuInput
         label="Test Label"
+        commitmentTotalInputsAreValid={true}
         inputValue={""}
         selectValue=""
         onInputValueChange={onInputValueChange}
@@ -24,6 +25,7 @@ describe("ProjectAmountMenuInput", () => {
     render(
       <ProjectAmountMenuInput
         label="Test Label"
+        commitmentTotalInputsAreValid={true}
         inputValue={""}
         selectValue=""
         onInputValueChange={onInputValueChange}
@@ -43,6 +45,7 @@ describe("ProjectAmountMenuInput", () => {
     render(
       <ProjectAmountMenuInput
         label="Test Label"
+        commitmentTotalInputsAreValid={true}
         inputValue={"123"}
         selectValue="M"
         onInputValueChange={onInputValueChange}
@@ -65,6 +68,7 @@ describe("ProjectAmountMenuInput", () => {
     render(
       <ProjectAmountMenuInput
         label="Test Label"
+        commitmentTotalInputsAreValid={true}
         inputValue={"123"}
         selectValue="M"
         onInputValueChange={onInputValueChange}
@@ -81,6 +85,7 @@ describe("ProjectAmountMenuInput", () => {
     render(
       <ProjectAmountMenuInput
         label="Test Label"
+        commitmentTotalInputsAreValid={true}
         inputValue={"123"}
         selectValue="M"
         onInputValueChange={onInputValueChange}

--- a/app/components/ProjectAmountMenu/ProjectAmountMenuInput.test.tsx
+++ b/app/components/ProjectAmountMenu/ProjectAmountMenuInput.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { ProjectAmountMenuInput } from "./ProjectAmountMenuInput";
+import { act } from "react";
+
+describe("ProjectAmountMenuInput", () => {
+  const onInputValueChange = vi.fn();
+  const onSelectValueChange = vi.fn();
+  it("should render with form details", () => {
+    render(
+      <ProjectAmountMenuInput
+        label="Test Label"
+        inputValue={""}
+        selectValue=""
+        onInputValueChange={onInputValueChange}
+        onSelectValueChange={onSelectValueChange}
+      />,
+    );
+
+    expect(screen.getByText("Test Label")).toBeInTheDocument();
+  });
+
+  it("should render with default input option (blank) select option (K)", () => {
+    render(
+      <ProjectAmountMenuInput
+        label="Test Label"
+        inputValue={""}
+        selectValue=""
+        onInputValueChange={onInputValueChange}
+        onSelectValueChange={onSelectValueChange}
+      />,
+    );
+
+    const input: HTMLInputElement = screen.getByDisplayValue("");
+    expect(input).toBeInTheDocument();
+    const options: Array<HTMLOptionElement> = screen.getAllByRole("option");
+    const defaultSelect = options.find((option) => option.value === "K");
+    expect(defaultSelect).toBeInTheDocument();
+    expect(defaultSelect?.selected).toBe(true);
+  });
+
+  it("should render with a passed input option and select option", () => {
+    render(
+      <ProjectAmountMenuInput
+        label="Test Label"
+        inputValue={"123"}
+        selectValue="M"
+        onInputValueChange={onInputValueChange}
+        onSelectValueChange={onSelectValueChange}
+      />,
+    );
+
+    const input: HTMLInputElement = screen.getByDisplayValue("123");
+    expect(input).toBeInTheDocument();
+    const options: Array<HTMLOptionElement> = screen.getAllByRole("option");
+    const defaultSelect = options.find((option) => option.value === "K");
+    expect(defaultSelect).toBeInTheDocument();
+    expect(defaultSelect?.selected).toBe(false);
+    const testSelect = options.find((option) => option.value === "M");
+    expect(testSelect).toBeInTheDocument();
+    expect(testSelect?.selected).toBe(true);
+  });
+
+  it("should call input function when input is changed", async () => {
+    render(
+      <ProjectAmountMenuInput
+        label="Test Label"
+        inputValue={"123"}
+        selectValue="M"
+        onInputValueChange={onInputValueChange}
+        onSelectValueChange={onSelectValueChange}
+      />,
+    );
+
+    const input: HTMLInputElement = screen.getByDisplayValue("123");
+    await act(() => userEvent.type(input, "1"));
+    expect(onInputValueChange).toHaveBeenCalled();
+  });
+
+  it("should call select function when select is changed", async () => {
+    render(
+      <ProjectAmountMenuInput
+        label="Test Label"
+        inputValue={"123"}
+        selectValue="M"
+        onInputValueChange={onInputValueChange}
+        onSelectValueChange={onSelectValueChange}
+      />,
+    );
+
+    const options: Array<HTMLOptionElement> = screen.getAllByRole("option");
+    const millionSelect = options.find((option) => option.value === "M");
+    expect(millionSelect).toBeInTheDocument();
+    expect(millionSelect?.selected).toBe(true);
+    const billionSelect = options.find((option) => option.value === "B");
+    expect(billionSelect).toBeInTheDocument();
+    expect(billionSelect?.selected).toBe(false);
+    await act(() => userEvent.selectOptions(screen.getByRole("combobox"), "B"));
+    expect(onSelectValueChange).toHaveBeenCalled();
+  });
+});

--- a/app/components/ProjectAmountMenu/ProjectAmountMenuInput.tsx
+++ b/app/components/ProjectAmountMenu/ProjectAmountMenuInput.tsx
@@ -5,6 +5,7 @@ export interface ProjectAmountMenuInputProps {
   label: string;
   inputValue?: null | string;
   selectValue: string;
+  commitmentTotalInputsAreValid: boolean;
   onInputValueChange?: (value: null | string) => void;
   onSelectValueChange?: (value: string) => void;
 }
@@ -12,6 +13,7 @@ export function ProjectAmountMenuInput({
   label,
   inputValue,
   selectValue,
+  commitmentTotalInputsAreValid,
   onInputValueChange = () => null,
   onSelectValueChange = () => null,
 }: ProjectAmountMenuInputProps) {
@@ -33,6 +35,7 @@ export function ProjectAmountMenuInput({
           type={"number"}
           onChange={(event) => onInputValueChange(event.target.value)}
           value={inputValue ?? ""}
+          isInvalid={!commitmentTotalInputsAreValid}
         />
         <Select
           iconSize="sm"
@@ -43,6 +46,7 @@ export function ProjectAmountMenuInput({
             onSelectValueChange(e.currentTarget.value)
           }
           value={selectValue ?? "K"}
+          isInvalid={!commitmentTotalInputsAreValid}
         >
           <option value="K">K</option>
           <option value="M">M</option>

--- a/app/components/ProjectAmountMenu/ProjectAmountMenuInput.tsx
+++ b/app/components/ProjectAmountMenu/ProjectAmountMenuInput.tsx
@@ -1,0 +1,54 @@
+import { Input, Flex, Select } from "@nycplanning/streetscape";
+import { FormEvent } from "react";
+
+export interface ProjectAmountMenuInputProps {
+  label: string;
+  inputValue?: null | string;
+  selectValue: string;
+  onInputValueChange?: (value: null | string) => void;
+  onSelectValueChange?: (value: string) => void;
+}
+export function ProjectAmountMenuInput({
+  label,
+  inputValue,
+  selectValue,
+  onInputValueChange = () => null,
+  onSelectValueChange = () => null,
+}: ProjectAmountMenuInputProps) {
+  return (
+    <Flex direction={"column"}>
+      <p
+        style={{
+          color: "var(--text-subtle)",
+          fontSize: "0.75rem",
+          letterSpacing: "0.18px",
+        }}
+      >
+        {label}
+      </p>
+      <Flex>
+        <Input
+          maxWidth={"4rem"}
+          borderRightRadius={0}
+          type={"number"}
+          onChange={(event) => onInputValueChange(event.target.value)}
+          value={inputValue ?? ""}
+        />
+        <Select
+          iconSize="sm"
+          borderLeftRadius={0}
+          maxWidth={"4rem"}
+          variant="base"
+          onChange={(e: FormEvent<HTMLSelectElement>) =>
+            onSelectValueChange(e.currentTarget.value)
+          }
+          value={selectValue ?? "K"}
+        >
+          <option value="K">K</option>
+          <option value="M">M</option>
+          <option value="B">B</option>
+        </Select>
+      </Flex>
+    </Flex>
+  );
+}

--- a/app/components/ProjectAmountMenu/index.test.tsx
+++ b/app/components/ProjectAmountMenu/index.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { ProjectAmountMenu } from ".";
+
+describe("ProjectAmountMenu", () => {
+  it("should render project amount label", () => {
+    render(
+      <ProjectAmountMenu
+        showClearButton={false}
+        onProjectAmountMenuClear={() => null}
+      >
+        Child Menus
+      </ProjectAmountMenu>,
+    );
+    expect(screen.getByText("Project Amount")).toBeInTheDocument();
+  });
+});

--- a/app/components/ProjectAmountMenu/index.tsx
+++ b/app/components/ProjectAmountMenu/index.tsx
@@ -1,0 +1,53 @@
+import { Flex, IconButton } from "@nycplanning/streetscape";
+import { CloseIcon } from "@chakra-ui/icons";
+import { ReactNode } from "react";
+
+export interface ProjectAmountMenuProps {
+  children: ReactNode;
+  showClearButton: boolean;
+  onProjectAmountMenuClear?: () => void;
+}
+export function ProjectAmountMenu({
+  children,
+  showClearButton,
+  onProjectAmountMenuClear = () => null,
+}: ProjectAmountMenuProps) {
+  return (
+    <>
+      <Flex width={"100%"} justifyContent={"space-between"}>
+        <h2 style={{ width: "100%", fontWeight: "500", paddingBottom: "0" }}>
+          Project Amount
+        </h2>
+        {showClearButton && (
+          <IconButton
+            aria-label={"Clear Project Amounts"}
+            variant="ghost"
+            _focus={{ borderWidth: 3, borderColor: "teal" }}
+            pos={"relative"}
+            minH={"unset"}
+            minW={"unset"}
+            height={"min-content"}
+            width={"min-content"}
+            top={2}
+            cursor={"pointer"}
+            onClick={() => {
+              onProjectAmountMenuClear();
+            }}
+            icon={
+              <CloseIcon
+                boxSize={3}
+                p={0.5}
+                border={"1px solid"}
+                borderRadius={16}
+              />
+            }
+          />
+        )}
+      </Flex>
+
+      <Flex width={"100%"} justifyContent={"space-between"}>
+        {children}
+      </Flex>
+    </>
+  );
+}

--- a/app/gen/axios/findAgencyBudgets.ts
+++ b/app/gen/axios/findAgencyBudgets.ts
@@ -4,14 +4,14 @@ import type { FindAgencyBudgetsQueryResponse } from "../types/FindAgencyBudgets"
 
 /**
  * @summary Find agency budgets
- * @link /agencyBugdets
+ * @link /agency-budgets
  */
 export async function findAgencyBudgets(
   options: Partial<Parameters<typeof client>[0]> = {},
 ): Promise<ResponseConfig<FindAgencyBudgetsQueryResponse>["data"]> {
   const res = await client<FindAgencyBudgetsQueryResponse>({
     method: "get",
-    url: `/agencyBugdets`,
+    url: `/agency-budgets`,
     baseURL: "https://zoning.planningdigital.com/api",
     ...options,
   });

--- a/app/gen/axios/operations.ts
+++ b/app/gen/axios/operations.ts
@@ -4,7 +4,7 @@ export const operations = {
     method: "get",
   },
   findAgencyBudgets: {
-    path: "/agencyBugdets",
+    path: "/agency-budgets",
     method: "get",
   },
   findBoroughs: {

--- a/app/gen/mocks/createCapitalProjectPage.ts
+++ b/app/gen/mocks/createCapitalProjectPage.ts
@@ -11,5 +11,6 @@ export function createCapitalProjectPage(
     capitalProjects: faker.helpers.arrayElements([
       createCapitalProject(),
     ]) as any,
+    totalProjects: faker.number.int(),
   });
 }

--- a/app/gen/mocks/createFindAgencies.ts
+++ b/app/gen/mocks/createFindAgencies.ts
@@ -10,10 +10,13 @@ import type {
 } from "../types/FindAgencies";
 
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export function createFindAgencies200(): NonNullable<FindAgencies200> {
-  return { agencies: faker.helpers.arrayElements([createAgency()]) as any };
+  return {
+    agencies: faker.helpers.arrayElements([createAgency()]) as any,
+    order: faker.string.alpha(),
+  };
 }
 
 /**
@@ -31,8 +34,11 @@ export function createFindAgencies500(): NonNullable<FindAgencies500> {
 }
 
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export function createFindAgenciesQueryResponse(): NonNullable<FindAgenciesQueryResponse> {
-  return { agencies: faker.helpers.arrayElements([createAgency()]) as any };
+  return {
+    agencies: faker.helpers.arrayElements([createAgency()]) as any,
+    order: faker.string.alpha(),
+  };
 }

--- a/app/gen/mocks/createFindCapitalProjects.ts
+++ b/app/gen/mocks/createFindCapitalProjects.ts
@@ -21,6 +21,15 @@ export function createFindCapitalProjectsQueryParams(): NonNullable<FindCapitalP
       new RandExp("^([0-9]{1,2})$").gen(),
     ]),
     managingAgency: faker.string.alpha(),
+    agencyBudget: faker.string.alpha(),
+    commitmentsTotalMin: faker.helpers.arrayElement<any>([
+      faker.string.alpha(),
+      new RandExp("^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\\.[0-9]{2})?$").gen(),
+    ]),
+    commitmentsTotalMax: faker.helpers.arrayElement<any>([
+      faker.string.alpha(),
+      new RandExp("^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\\.[0-9]{2})?$").gen(),
+    ]),
     limit: faker.number.int(),
     offset: faker.number.int(),
   };

--- a/app/gen/mocks/createFindCapitalProjectsByBoroughIdCommunityDistrictId.ts
+++ b/app/gen/mocks/createFindCapitalProjectsByBoroughIdCommunityDistrictId.ts
@@ -7,7 +7,6 @@ import type {
   FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams,
   FindCapitalProjectsByBoroughIdCommunityDistrictId200,
   FindCapitalProjectsByBoroughIdCommunityDistrictId400,
-  FindCapitalProjectsByBoroughIdCommunityDistrictId404,
   FindCapitalProjectsByBoroughIdCommunityDistrictId500,
   FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponse,
 } from "../types/FindCapitalProjectsByBoroughIdCommunityDistrictId";
@@ -40,13 +39,6 @@ export function createFindCapitalProjectsByBoroughIdCommunityDistrictId200(): No
  * @description Invalid client request
  */
 export function createFindCapitalProjectsByBoroughIdCommunityDistrictId400(): NonNullable<FindCapitalProjectsByBoroughIdCommunityDistrictId400> {
-  return createError();
-}
-
-/**
- * @description Requested resource does not exist or is not available
- */
-export function createFindCapitalProjectsByBoroughIdCommunityDistrictId404(): NonNullable<FindCapitalProjectsByBoroughIdCommunityDistrictId404> {
   return createError();
 }
 

--- a/app/gen/mocks/createFindCapitalProjectsByCityCouncilId.ts
+++ b/app/gen/mocks/createFindCapitalProjectsByCityCouncilId.ts
@@ -7,7 +7,6 @@ import type {
   FindCapitalProjectsByCityCouncilIdQueryParams,
   FindCapitalProjectsByCityCouncilId200,
   FindCapitalProjectsByCityCouncilId400,
-  FindCapitalProjectsByCityCouncilId404,
   FindCapitalProjectsByCityCouncilId500,
   FindCapitalProjectsByCityCouncilIdQueryResponse,
 } from "../types/FindCapitalProjectsByCityCouncilId";
@@ -36,13 +35,6 @@ export function createFindCapitalProjectsByCityCouncilId200(): NonNullable<FindC
  * @description Invalid client request
  */
 export function createFindCapitalProjectsByCityCouncilId400(): NonNullable<FindCapitalProjectsByCityCouncilId400> {
-  return createError();
-}
-
-/**
- * @description Requested resource does not exist or is not available
- */
-export function createFindCapitalProjectsByCityCouncilId404(): NonNullable<FindCapitalProjectsByCityCouncilId404> {
   return createError();
 }
 

--- a/app/gen/mocks/findAgencyBudgetsHandler.ts
+++ b/app/gen/mocks/findAgencyBudgetsHandler.ts
@@ -2,7 +2,7 @@ import { http } from "msw";
 import { createFindAgencyBudgetsQueryResponse } from "./createFindAgencyBudgets";
 
 export const findAgencyBudgetsHandler = http.get(
-  "*/agencyBugdets",
+  "*/agency-budgets",
   function handler(info) {
     return new Response(
       JSON.stringify(createFindAgencyBudgetsQueryResponse()),

--- a/app/gen/types/CapitalProjectPage.ts
+++ b/app/gen/types/CapitalProjectPage.ts
@@ -6,4 +6,9 @@ export type CapitalProjectPage = Page & {
    * @type array
    */
   capitalProjects: CapitalProject[];
+  /**
+   * @description The total number of results matching the query parameters.
+   * @type integer
+   */
+  totalProjects: number;
 };

--- a/app/gen/types/FindAgencies.ts
+++ b/app/gen/types/FindAgencies.ts
@@ -2,13 +2,19 @@ import type { Agency } from "./Agency";
 import type { Error } from "./Error";
 
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export type FindAgencies200 = {
   /**
+   * @description An list of agencies sorted alphabetically by the agency initials.\n
    * @type array
    */
   agencies: Agency[];
+  /**
+   * @description The criteria used to sort the results using the agency initials in ascending order.
+   * @type string
+   */
+  order: string;
 };
 /**
  * @description Invalid client request
@@ -19,13 +25,19 @@ export type FindAgencies400 = Error;
  */
 export type FindAgencies500 = Error;
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export type FindAgenciesQueryResponse = {
   /**
+   * @description An list of agencies sorted alphabetically by the agency initials.\n
    * @type array
    */
   agencies: Agency[];
+  /**
+   * @description The criteria used to sort the results using the agency initials in ascending order.
+   * @type string
+   */
+  order: string;
 };
 export type FindAgenciesQuery = {
   Response: FindAgenciesQueryResponse;

--- a/app/gen/types/FindCapitalProjects.ts
+++ b/app/gen/types/FindCapitalProjects.ts
@@ -18,6 +18,21 @@ export type FindCapitalProjectsQueryParams = {
    */
   managingAgency?: string;
   /**
+   * @description The two character alphabetic string containing the letters used to refer to the agency budget code.
+   * @type string | undefined
+   */
+  agencyBudget?: string;
+  /**
+   * @description Minimum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.
+   * @type string | undefined
+   */
+  commitmentsTotalMin?: string;
+  /**
+   * @description Maximum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.
+   * @type string | undefined
+   */
+  commitmentsTotalMax?: string;
+  /**
    * @description The maximum number of results to be returned in each response. The default value is 20. It must be between 1 and 100, inclusive.
    * @type integer | undefined
    */

--- a/app/gen/types/FindCapitalProjectsByBoroughIdCommunityDistrictId.ts
+++ b/app/gen/types/FindCapitalProjectsByBoroughIdCommunityDistrictId.ts
@@ -35,10 +35,6 @@ export type FindCapitalProjectsByBoroughIdCommunityDistrictId200 =
  */
 export type FindCapitalProjectsByBoroughIdCommunityDistrictId400 = Error;
 /**
- * @description Requested resource does not exist or is not available
- */
-export type FindCapitalProjectsByBoroughIdCommunityDistrictId404 = Error;
-/**
  * @description Server side error
  */
 export type FindCapitalProjectsByBoroughIdCommunityDistrictId500 = Error;
@@ -53,6 +49,5 @@ export type FindCapitalProjectsByBoroughIdCommunityDistrictIdQuery = {
   QueryParams: FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams;
   Errors:
     | FindCapitalProjectsByBoroughIdCommunityDistrictId400
-    | FindCapitalProjectsByBoroughIdCommunityDistrictId404
     | FindCapitalProjectsByBoroughIdCommunityDistrictId500;
 };

--- a/app/gen/types/FindCapitalProjectsByCityCouncilId.ts
+++ b/app/gen/types/FindCapitalProjectsByCityCouncilId.ts
@@ -29,10 +29,6 @@ export type FindCapitalProjectsByCityCouncilId200 = CapitalProjectPage;
  */
 export type FindCapitalProjectsByCityCouncilId400 = Error;
 /**
- * @description Requested resource does not exist or is not available
- */
-export type FindCapitalProjectsByCityCouncilId404 = Error;
-/**
  * @description Server side error
  */
 export type FindCapitalProjectsByCityCouncilId500 = Error;
@@ -47,6 +43,5 @@ export type FindCapitalProjectsByCityCouncilIdQuery = {
   QueryParams: FindCapitalProjectsByCityCouncilIdQueryParams;
   Errors:
     | FindCapitalProjectsByCityCouncilId400
-    | FindCapitalProjectsByCityCouncilId404
     | FindCapitalProjectsByCityCouncilId500;
 };

--- a/app/gen/zod/capitalProjectPageSchema.ts
+++ b/app/gen/zod/capitalProjectPageSchema.ts
@@ -5,5 +5,12 @@ import { z } from "zod";
 export const capitalProjectPageSchema = z
   .lazy(() => pageSchema)
   .and(
-    z.object({ capitalProjects: z.array(z.lazy(() => capitalProjectSchema)) }),
+    z.object({
+      capitalProjects: z.array(z.lazy(() => capitalProjectSchema)),
+      totalProjects: z
+        .number()
+        .int()
+        .min(0)
+        .describe("The total number of results matching the query parameters."),
+    }),
   );

--- a/app/gen/zod/findAgenciesSchema.ts
+++ b/app/gen/zod/findAgenciesSchema.ts
@@ -3,10 +3,19 @@ import { agencySchema } from "./agencySchema";
 import { errorSchema } from "./errorSchema";
 
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export const findAgencies200Schema = z.object({
-  agencies: z.array(z.lazy(() => agencySchema)),
+  agencies: z
+    .array(z.lazy(() => agencySchema))
+    .describe(
+      "An list of agencies sorted alphabetically by the agency initials.\n",
+    ),
+  order: z
+    .string()
+    .describe(
+      "The criteria used to sort the results using the agency initials in ascending order.",
+    ),
 });
 /**
  * @description Invalid client request
@@ -17,8 +26,17 @@ export const findAgencies400Schema = z.lazy(() => errorSchema);
  */
 export const findAgencies500Schema = z.lazy(() => errorSchema);
 /**
- * @description An object containing all agencies.
+ * @description An object containing all agencies sorted alphabetically by the agency initials.\n
  */
 export const findAgenciesQueryResponseSchema = z.object({
-  agencies: z.array(z.lazy(() => agencySchema)),
+  agencies: z
+    .array(z.lazy(() => agencySchema))
+    .describe(
+      "An list of agencies sorted alphabetically by the agency initials.\n",
+    ),
+  order: z
+    .string()
+    .describe(
+      "The criteria used to sort the results using the agency initials in ascending order.",
+    ),
 });

--- a/app/gen/zod/findCapitalProjectsByBoroughIdCommunityDistrictIdSchema.ts
+++ b/app/gen/zod/findCapitalProjectsByBoroughIdCommunityDistrictIdSchema.ts
@@ -51,11 +51,6 @@ export const findCapitalProjectsByBoroughIdCommunityDistrictId200Schema =
 export const findCapitalProjectsByBoroughIdCommunityDistrictId400Schema =
   z.lazy(() => errorSchema);
 /**
- * @description Requested resource does not exist or is not available
- */
-export const findCapitalProjectsByBoroughIdCommunityDistrictId404Schema =
-  z.lazy(() => errorSchema);
-/**
  * @description Server side error
  */
 export const findCapitalProjectsByBoroughIdCommunityDistrictId500Schema =

--- a/app/gen/zod/findCapitalProjectsByCityCouncilIdSchema.ts
+++ b/app/gen/zod/findCapitalProjectsByCityCouncilIdSchema.ts
@@ -43,12 +43,6 @@ export const findCapitalProjectsByCityCouncilId400Schema = z.lazy(
   () => errorSchema,
 );
 /**
- * @description Requested resource does not exist or is not available
- */
-export const findCapitalProjectsByCityCouncilId404Schema = z.lazy(
-  () => errorSchema,
-);
-/**
  * @description Server side error
  */
 export const findCapitalProjectsByCityCouncilId500Schema = z.lazy(

--- a/app/gen/zod/findCapitalProjectsSchema.ts
+++ b/app/gen/zod/findCapitalProjectsSchema.ts
@@ -22,6 +22,26 @@ export const findCapitalProjectsQueryParamsSchema = z
       .string()
       .describe("The acronym of the managing agency to filter the projects by.")
       .optional(),
+    agencyBudget: z
+      .string()
+      .describe(
+        "The two character alphabetic string containing the letters used to refer to the agency budget code.",
+      )
+      .optional(),
+    commitmentsTotalMin: z
+      .string()
+      .regex(new RegExp("^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\\.[0-9]{2})?$"))
+      .describe(
+        "Minimum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.",
+      )
+      .optional(),
+    commitmentsTotalMax: z
+      .string()
+      .regex(new RegExp("^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\\.[0-9]{2})?$"))
+      .describe(
+        "Maximum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.",
+      )
+      .optional(),
     limit: z
       .number()
       .int()

--- a/app/gen/zod/operations.ts
+++ b/app/gen/zod/operations.ts
@@ -30,7 +30,6 @@ import {
 import {
   findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
   findCapitalProjectsByBoroughIdCommunityDistrictId400Schema,
-  findCapitalProjectsByBoroughIdCommunityDistrictId404Schema,
   findCapitalProjectsByBoroughIdCommunityDistrictId500Schema,
   findCapitalProjectsByBoroughIdCommunityDistrictIdPathParamsSchema,
   findCapitalProjectsByBoroughIdCommunityDistrictIdQueryParamsSchema,
@@ -100,7 +99,6 @@ import {
 import {
   findCapitalProjectsByCityCouncilIdQueryResponseSchema,
   findCapitalProjectsByCityCouncilId400Schema,
-  findCapitalProjectsByCityCouncilId404Schema,
   findCapitalProjectsByCityCouncilId500Schema,
   findCapitalProjectsByCityCouncilIdPathParamsSchema,
   findCapitalProjectsByCityCouncilIdQueryParamsSchema,
@@ -294,14 +292,12 @@ export const operations = {
     responses: {
       200: findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
       400: findCapitalProjectsByBoroughIdCommunityDistrictId400Schema,
-      404: findCapitalProjectsByBoroughIdCommunityDistrictId404Schema,
       500: findCapitalProjectsByBoroughIdCommunityDistrictId500Schema,
       default:
         findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
     },
     errors: {
       400: findCapitalProjectsByBoroughIdCommunityDistrictId400Schema,
-      404: findCapitalProjectsByBoroughIdCommunityDistrictId404Schema,
       500: findCapitalProjectsByBoroughIdCommunityDistrictId500Schema,
     },
   },
@@ -509,13 +505,11 @@ export const operations = {
     responses: {
       200: findCapitalProjectsByCityCouncilIdQueryResponseSchema,
       400: findCapitalProjectsByCityCouncilId400Schema,
-      404: findCapitalProjectsByCityCouncilId404Schema,
       500: findCapitalProjectsByCityCouncilId500Schema,
       default: findCapitalProjectsByCityCouncilIdQueryResponseSchema,
     },
     errors: {
       400: findCapitalProjectsByCityCouncilId400Schema,
-      404: findCapitalProjectsByCityCouncilId404Schema,
       500: findCapitalProjectsByCityCouncilId500Schema,
     },
   },
@@ -773,7 +767,7 @@ export const paths = {
   "/agencies": {
     get: operations["findAgencies"],
   },
-  "/agencyBugdets": {
+  "/agency-budgets": {
     get: operations["findAgencyBudgets"],
   },
   "/boroughs": {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -458,7 +458,6 @@ export default function App() {
                               });
                             }}
                             onSelectValueChange={(value) => {
-                              console.log("min select", value);
                               setAttributeParams({
                                 ...attributeParams,
                                 commitmentsTotalMinSelectValue: value,
@@ -497,7 +496,6 @@ export default function App() {
                               });
                             }}
                             onSelectValueChange={(value) => {
-                              console.log("max select", value);
                               setAttributeParams({
                                 ...attributeParams,
                                 commitmentsTotalMaxSelectValue: value,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -55,6 +55,8 @@ import {
 import {
   setNewSearchParams,
   handleCommitmentTotalsInputs,
+  checkCommitmentTotalInputsAreValid,
+  getMultiplier,
 } from "./utils/utils";
 import {
   BoroughId,
@@ -66,6 +68,10 @@ import {
   AgencyBudgetType,
   CommitmentsTotalMin,
   CommitmentsTotalMax,
+  CommitmentsTotalMinInputValue,
+  CommitmentsTotalMaxInputValue,
+  CommitmentsTotalMinSelectValue,
+  CommitmentsTotalMaxSelectValue,
 } from "./utils/types";
 import { ProjectAmountMenu } from "./components/ProjectAmountMenu";
 import { ProjectAmountMenuInput } from "./components/ProjectAmountMenu/ProjectAmountMenuInput";
@@ -208,6 +214,13 @@ export default function App() {
     commitmentsTotalMaxSelectValue,
   } = handleCommitmentTotalsInputs(commitmentsTotalMin, commitmentsTotalMax);
 
+  const commitmentTotalInputsAreValid = checkCommitmentTotalInputsAreValid({
+    commitmentsTotalMinInputValue,
+    commitmentsTotalMinSelectValue,
+    commitmentsTotalMaxInputValue,
+    commitmentsTotalMaxSelectValue,
+  });
+
   const [attributeParams, setAttributeParams] = useState<AttributeParams>({
     managingAgency,
     agencyBudget,
@@ -217,6 +230,7 @@ export default function App() {
     commitmentsTotalMinSelectValue,
     commitmentsTotalMaxInputValue,
     commitmentsTotalMaxSelectValue,
+    commitmentTotalInputsAreValid,
   });
 
   const loaderData = useLoaderData<
@@ -280,59 +294,25 @@ export default function App() {
         attributeParams.commitmentsTotalMinInputValue !== "" &&
         parseFloat(attributeParams.commitmentsTotalMinInputValue)
       ) {
-        if (attributeParams.commitmentsTotalMinSelectValue === "B") {
-          nextAdminParams.set(
-            "commitmentsTotalMin",
-            (
-              parseFloat(attributeParams.commitmentsTotalMinInputValue) *
-              1000000000
-            ).toString(),
-          );
-        } else if (attributeParams.commitmentsTotalMinSelectValue === "M") {
-          nextAdminParams.set(
-            "commitmentsTotalMin",
-            (
-              parseFloat(attributeParams.commitmentsTotalMinInputValue) *
-              1000000
-            ).toString(),
-          );
-        } else {
-          nextAdminParams.set(
-            "commitmentsTotalMin",
-            (
-              parseFloat(attributeParams.commitmentsTotalMinInputValue) * 1000
-            ).toString(),
-          );
-        }
+        nextAdminParams.set(
+          "commitmentsTotalMin",
+          (
+            parseFloat(attributeParams.commitmentsTotalMinInputValue) *
+            getMultiplier(attributeParams.commitmentsTotalMinSelectValue)
+          ).toString(),
+        );
       }
       if (
         attributeParams.commitmentsTotalMaxInputValue !== "" &&
         parseFloat(attributeParams.commitmentsTotalMaxInputValue)
       ) {
-        if (attributeParams.commitmentsTotalMaxSelectValue === "B") {
-          nextAdminParams.set(
-            "commitmentsTotalMax",
-            (
-              parseFloat(attributeParams.commitmentsTotalMaxInputValue) *
-              1000000000
-            ).toString(),
-          );
-        } else if (attributeParams.commitmentsTotalMaxSelectValue === "M") {
-          nextAdminParams.set(
-            "commitmentsTotalMax",
-            (
-              parseFloat(attributeParams.commitmentsTotalMaxInputValue) *
-              1000000
-            ).toString(),
-          );
-        } else {
-          nextAdminParams.set(
-            "commitmentsTotalMax",
-            (
-              parseFloat(attributeParams.commitmentsTotalMaxInputValue) * 1000
-            ).toString(),
-          );
-        }
+        nextAdminParams.set(
+          "commitmentsTotalMax",
+          (
+            parseFloat(attributeParams.commitmentsTotalMaxInputValue) *
+            getMultiplier(attributeParams.commitmentsTotalMaxSelectValue)
+          ).toString(),
+        );
       }
 
       analytics({
@@ -443,6 +423,9 @@ export default function App() {
                         >
                           <ProjectAmountMenuInput
                             label={"Minimum"}
+                            commitmentTotalInputsAreValid={
+                              attributeParams.commitmentTotalInputsAreValid
+                            }
                             inputValue={
                               attributeParams.commitmentsTotalMinInputValue
                             }
@@ -450,17 +433,41 @@ export default function App() {
                               attributeParams.commitmentsTotalMinSelectValue
                             }
                             onInputValueChange={(value) => {
+                              const commitmentTotalInputsAreValid =
+                                checkCommitmentTotalInputsAreValid({
+                                  commitmentsTotalMinInputValue:
+                                    value as CommitmentsTotalMinInputValue,
+                                  commitmentsTotalMaxInputValue:
+                                    attributeParams.commitmentsTotalMaxInputValue as CommitmentsTotalMaxInputValue,
+                                  commitmentsTotalMinSelectValue:
+                                    attributeParams.commitmentsTotalMinSelectValue as CommitmentsTotalMinSelectValue,
+                                  commitmentsTotalMaxSelectValue:
+                                    attributeParams.commitmentsTotalMaxSelectValue as CommitmentsTotalMaxSelectValue,
+                                });
                               setAttributeParams({
                                 ...attributeParams,
                                 commitmentsTotalMinInputValue: value
                                   ? value
                                   : "",
+                                commitmentTotalInputsAreValid,
                               });
                             }}
                             onSelectValueChange={(value) => {
+                              const commitmentTotalInputsAreValid =
+                                checkCommitmentTotalInputsAreValid({
+                                  commitmentsTotalMinInputValue:
+                                    attributeParams.commitmentsTotalMinInputValue as CommitmentsTotalMinInputValue,
+                                  commitmentsTotalMaxInputValue:
+                                    attributeParams.commitmentsTotalMaxInputValue as CommitmentsTotalMaxInputValue,
+                                  commitmentsTotalMinSelectValue:
+                                    value as CommitmentsTotalMinSelectValue,
+                                  commitmentsTotalMaxSelectValue:
+                                    attributeParams.commitmentsTotalMaxSelectValue as CommitmentsTotalMaxSelectValue,
+                                });
                               setAttributeParams({
                                 ...attributeParams,
                                 commitmentsTotalMinSelectValue: value,
+                                commitmentTotalInputsAreValid,
                               });
                             }}
                           />
@@ -481,6 +488,9 @@ export default function App() {
 
                           <ProjectAmountMenuInput
                             label={"Maximum"}
+                            commitmentTotalInputsAreValid={
+                              attributeParams.commitmentTotalInputsAreValid
+                            }
                             inputValue={
                               attributeParams.commitmentsTotalMaxInputValue
                             }
@@ -488,17 +498,41 @@ export default function App() {
                               attributeParams.commitmentsTotalMaxSelectValue
                             }
                             onInputValueChange={(value) => {
+                              const commitmentTotalInputsAreValid =
+                                checkCommitmentTotalInputsAreValid({
+                                  commitmentsTotalMinInputValue:
+                                    attributeParams.commitmentsTotalMinInputValue as CommitmentsTotalMinInputValue,
+                                  commitmentsTotalMaxInputValue:
+                                    value as CommitmentsTotalMaxInputValue,
+                                  commitmentsTotalMinSelectValue:
+                                    attributeParams.commitmentsTotalMinSelectValue as CommitmentsTotalMinSelectValue,
+                                  commitmentsTotalMaxSelectValue:
+                                    attributeParams.commitmentsTotalMaxSelectValue as CommitmentsTotalMaxSelectValue,
+                                });
                               setAttributeParams({
                                 ...attributeParams,
                                 commitmentsTotalMaxInputValue: value
                                   ? value
                                   : "",
+                                commitmentTotalInputsAreValid,
                               });
                             }}
                             onSelectValueChange={(value) => {
+                              const commitmentTotalInputsAreValid =
+                                checkCommitmentTotalInputsAreValid({
+                                  commitmentsTotalMinInputValue:
+                                    attributeParams.commitmentsTotalMinInputValue as CommitmentsTotalMinInputValue,
+                                  commitmentsTotalMaxInputValue:
+                                    attributeParams.commitmentsTotalMaxInputValue as CommitmentsTotalMaxInputValue,
+                                  commitmentsTotalMinSelectValue:
+                                    attributeParams.commitmentsTotalMinSelectValue as CommitmentsTotalMinSelectValue,
+                                  commitmentsTotalMaxSelectValue:
+                                    value as CommitmentsTotalMaxSelectValue,
+                                });
                               setAttributeParams({
                                 ...attributeParams,
                                 commitmentsTotalMaxSelectValue: value,
+                                commitmentTotalInputsAreValid,
                               });
                             }}
                           />
@@ -519,7 +553,8 @@ export default function App() {
                           attributeParams.commitmentsTotalMaxInputValue ===
                             "" &&
                           !districtId) ||
-                        (districtType && !districtId)
+                        (districtType && !districtId) ||
+                        !attributeParams.commitmentTotalInputsAreValid
                           ? true
                           : false
                       }

--- a/app/routes/boroughs.$boroughId.community-districts.$communityDistrictId.capital-projects.tsx
+++ b/app/routes/boroughs.$boroughId.community-districts.$communityDistrictId.capital-projects.tsx
@@ -17,6 +17,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const pageParam = url.searchParams.get("page");
   const managingAgency = url.searchParams.get("managingAgency");
   const agencyBudget = url.searchParams.get("agencyBudget");
+  const commitmentsTotalMin = url.searchParams.get("commitmentsTotalMin");
+  const commitmentsTotalMax = url.searchParams.get("commitmentsTotalMax");
   const page = pageParam === null ? 1 : parseInt(pageParam);
 
   const { boroughId, communityDistrictId } = params;
@@ -36,6 +38,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       offset: offset,
       ...(managingAgency === null ? {} : { managingAgency }),
       ...(agencyBudget === null ? {} : { agencyBudget }),
+      ...(commitmentsTotalMin === null ? {} : { commitmentsTotalMin }),
+      ...(commitmentsTotalMax === null ? {} : { commitmentsTotalMax }),
     },
     {
       baseURL: `${import.meta.env.VITE_ZONING_API_URL}/api`,

--- a/app/routes/capital-projects.tsx
+++ b/app/routes/capital-projects.tsx
@@ -15,6 +15,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const pageParam = url.searchParams.get("page");
   const managingAgency = url.searchParams.get("managingAgency");
   const agencyBudget = url.searchParams.get("agencyBudget");
+  const commitmentsTotalMin = url.searchParams.get("commitmentsTotalMin");
+  const commitmentsTotalMax = url.searchParams.get("commitmentsTotalMax");
   const page = pageParam === null ? 1 : parseInt(pageParam);
   if (isNaN(page)) {
     throw json("Bad Request", { status: 400 });
@@ -25,6 +27,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     {
       ...(managingAgency === null ? {} : { managingAgency }),
       ...(agencyBudget === null ? {} : { agencyBudget }),
+      ...(commitmentsTotalMin === null ? {} : { commitmentsTotalMin }),
+      ...(commitmentsTotalMax === null ? {} : { commitmentsTotalMax }),
       limit: itemsPerPage,
       offset: offset,
     },

--- a/app/routes/city-council-districts.$cityCouncilDistrictId.capital-projects.tsx
+++ b/app/routes/city-council-districts.$cityCouncilDistrictId.capital-projects.tsx
@@ -12,6 +12,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const pageParam = url.searchParams.get("page");
   const managingAgency = url.searchParams.get("managingAgency");
   const agencyBudget = url.searchParams.get("agencyBudget");
+  const commitmentsTotalMin = url.searchParams.get("commitmentsTotalMin");
+  const commitmentsTotalMax = url.searchParams.get("commitmentsTotalMax");
   const page = pageParam === null ? 1 : parseInt(pageParam);
   const { cityCouncilDistrictId } = params;
   if (cityCouncilDistrictId === undefined || isNaN(page)) {
@@ -26,6 +28,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       offset: offset,
       ...(managingAgency === null ? {} : { managingAgency }),
       ...(agencyBudget === null ? {} : { agencyBudget }),
+      ...(commitmentsTotalMin === null ? {} : { commitmentsTotalMin }),
+      ...(commitmentsTotalMax === null ? {} : { commitmentsTotalMax }),
     },
     {
       baseURL: `${import.meta.env.VITE_ZONING_API_URL}/api`,

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -2,6 +2,7 @@ export type BoroughId = null | string;
 export type DistrictType = null | "cd" | "ccd";
 export type DistrictId = null | string;
 export type ManagingAgencyAcronym = null | string;
+export type AgencyBudgetType = null | string;
 
 export type AdminParams = {
   districtType: DistrictType;
@@ -11,6 +12,7 @@ export type AdminParams = {
 
 export type AttributeParams = {
   managingAgency: ManagingAgencyAcronym;
+  agencyBudget: AgencyBudgetType;
 };
 
 export type SearchParamChanges = Record<

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -3,6 +3,12 @@ export type DistrictType = null | "cd" | "ccd";
 export type DistrictId = null | string;
 export type ManagingAgencyAcronym = null | string;
 export type AgencyBudgetType = null | string;
+export type CommitmentsTotalMin = null | string;
+export type CommitmentsTotalMax = null | string;
+export type CommitmentsTotalMinInputValue = string;
+export type CommitmentsTotalMinSelectValue = string;
+export type CommitmentsTotalMaxInputValue = string;
+export type CommitmentsTotalMaxSelectValue = string;
 
 export type AdminParams = {
   districtType: DistrictType;
@@ -13,6 +19,12 @@ export type AdminParams = {
 export type AttributeParams = {
   managingAgency: ManagingAgencyAcronym;
   agencyBudget: AgencyBudgetType;
+  commitmentsTotalMin: CommitmentsTotalMin;
+  commitmentsTotalMax: CommitmentsTotalMax;
+  commitmentsTotalMinInputValue: CommitmentsTotalMinInputValue;
+  commitmentsTotalMinSelectValue: CommitmentsTotalMinSelectValue;
+  commitmentsTotalMaxInputValue: CommitmentsTotalMaxInputValue;
+  commitmentsTotalMaxSelectValue: CommitmentsTotalMaxSelectValue;
 };
 
 export type SearchParamChanges = Record<

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -9,6 +9,7 @@ export type CommitmentsTotalMinInputValue = string;
 export type CommitmentsTotalMinSelectValue = string;
 export type CommitmentsTotalMaxInputValue = string;
 export type CommitmentsTotalMaxSelectValue = string;
+export type CommitmentTotalInputsAreValid = boolean;
 
 export type AdminParams = {
   districtType: DistrictType;
@@ -25,6 +26,7 @@ export type AttributeParams = {
   commitmentsTotalMinSelectValue: CommitmentsTotalMinSelectValue;
   commitmentsTotalMaxInputValue: CommitmentsTotalMaxInputValue;
   commitmentsTotalMaxSelectValue: CommitmentsTotalMaxSelectValue;
+  commitmentTotalInputsAreValid: CommitmentTotalInputsAreValid;
 };
 
 export type SearchParamChanges = Record<

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -1,5 +1,13 @@
 import { compareAsc, format, getMonth, getYear } from "date-fns";
-import { SearchParamChanges } from "./types";
+import {
+  SearchParamChanges,
+  CommitmentsTotalMin,
+  CommitmentsTotalMax,
+  CommitmentsTotalMinInputValue,
+  CommitmentsTotalMaxInputValue,
+  CommitmentsTotalMinSelectValue,
+  CommitmentsTotalMaxSelectValue,
+} from "./types";
 
 const getFiscalYearForDate = (date: Date): number => {
   const year = getYear(date);
@@ -15,6 +23,57 @@ export const formatFiscalYearRange = (minDate: Date, maxDate: Date) => {
 
 export const currentDate = () => {
   return `${format(new Date(), "MM/dd/yyyy")}`;
+};
+
+export const handleCommitmentTotalsInputs = (
+  commitmentsTotalMin: CommitmentsTotalMin,
+  commitmentsTotalMax: CommitmentsTotalMax,
+) => {
+  let commitmentsTotalMinInputValue = "" as CommitmentsTotalMinInputValue;
+  let commitmentsTotalMaxInputValue = "" as CommitmentsTotalMaxInputValue;
+  let commitmentsTotalMinSelectValue = "K" as CommitmentsTotalMinSelectValue;
+  let commitmentsTotalMaxSelectValue = "K" as CommitmentsTotalMaxSelectValue;
+  if (commitmentsTotalMin && parseFloat(commitmentsTotalMin)) {
+    if (parseFloat(commitmentsTotalMin) >= 1000000000) {
+      commitmentsTotalMinInputValue = (
+        parseFloat(commitmentsTotalMin) / 1000000000
+      ).toString();
+      commitmentsTotalMinSelectValue = "B";
+    } else if (parseFloat(commitmentsTotalMin) >= 1000000) {
+      commitmentsTotalMinInputValue = (
+        parseFloat(commitmentsTotalMin) / 1000000
+      ).toString();
+      commitmentsTotalMinSelectValue = "M";
+    } else if (parseFloat(commitmentsTotalMin) >= 1000) {
+      commitmentsTotalMinInputValue = (
+        parseFloat(commitmentsTotalMin) / 1000
+      ).toString();
+    }
+  }
+  if (commitmentsTotalMax && parseFloat(commitmentsTotalMax)) {
+    if (parseFloat(commitmentsTotalMax) >= 1000000000) {
+      commitmentsTotalMaxInputValue = (
+        parseFloat(commitmentsTotalMax) / 1000000000
+      ).toString();
+      commitmentsTotalMaxSelectValue = "B";
+    } else if (parseFloat(commitmentsTotalMax) >= 1000000) {
+      commitmentsTotalMaxInputValue = (
+        parseFloat(commitmentsTotalMax) / 1000000
+      ).toString();
+      commitmentsTotalMaxSelectValue = "M";
+    } else if (parseFloat(commitmentsTotalMax) >= 1000) {
+      commitmentsTotalMaxInputValue = (
+        parseFloat(commitmentsTotalMax) / 1000
+      ).toString();
+    }
+  }
+
+  return {
+    commitmentsTotalMinInputValue,
+    commitmentsTotalMinSelectValue,
+    commitmentsTotalMaxInputValue,
+    commitmentsTotalMaxSelectValue,
+  };
 };
 
 // from https://www.jacobparis.com/content/remix-pagination

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -76,6 +76,44 @@ export const handleCommitmentTotalsInputs = (
   };
 };
 
+export function getMultiplier(multiplier: string) {
+  switch (multiplier) {
+    case "B":
+      return 1000000000;
+    case "M":
+      return 1000000;
+    case "K":
+      return 1000;
+    default:
+      return 1;
+  }
+}
+
+export interface CheckCommitmentTotalInputsAreValidProps {
+  commitmentsTotalMinInputValue: CommitmentsTotalMinInputValue;
+  commitmentsTotalMaxInputValue: CommitmentsTotalMaxInputValue;
+  commitmentsTotalMinSelectValue: CommitmentsTotalMinSelectValue;
+  commitmentsTotalMaxSelectValue: CommitmentsTotalMaxSelectValue;
+}
+
+export const checkCommitmentTotalInputsAreValid = ({
+  commitmentsTotalMinInputValue,
+  commitmentsTotalMaxInputValue,
+  commitmentsTotalMinSelectValue,
+  commitmentsTotalMaxSelectValue,
+}: CheckCommitmentTotalInputsAreValidProps) => {
+  if (!commitmentsTotalMinInputValue || !commitmentsTotalMaxInputValue)
+    return true;
+  const min =
+    parseFloat(commitmentsTotalMinInputValue) *
+    getMultiplier(commitmentsTotalMinSelectValue);
+  const max =
+    parseFloat(commitmentsTotalMaxInputValue) *
+    getMultiplier(commitmentsTotalMaxSelectValue);
+  if (min <= max) return true;
+  return false;
+};
+
 // from https://www.jacobparis.com/content/remix-pagination
 export function setNewSearchParams(
   searchParams: URLSearchParams,


### PR DESCRIPTION
# #158 
## Acceptance Criteria

- [x] Add new Project Type filter to "Search by Attribute" menu ([designs](https://www.figma.com/design/LYHHoPop9l0jpEivk5CFzJ/Capital-Projects-Portal?node-id=3040-8347&t=6DJJiMHdTYgBMpyB-0))
- [x] Populate dropdown with budget types, using endpoint added in https://github.com/NYCPlanning/ae-zoning-api/issues/401
- [x] When user selects a Project Type and clicks "Search", new `agencyBudget` query param populates in the browser with the corresponding agency budget code. Query param should not populate immediately when a dropdown selection is made
- [x] When user selects a Project Type and clicks "Search", capital projects list updates to only include projects for the given project type and match other filters
- [ ] ~~When user selects a Project Type and clicks "Search", projects displayed on the map update to only include projects for the given project type and match other filters. Map filtering relies on new attribute to be added in https://github.com/NYCPlanning/ae-zoning-api/issues/427~~

# #159 
## Acceptance Criteria

- [x] Add new Project Amount filter to "Search by Attribute" menu ([designs](https://www.figma.com/design/LYHHoPop9l0jpEivk5CFzJ/Capital-Projects-Portal?node-id=3040-8347&t=6DJJiMHdTYgBMpyB-0))
- [x] Min and Max filters have dropdowns for "K", "M", and "B" for thousands, millions, billions.
- [x] When user selects a min and/or max project amount and clicks "Search", new `commitmentsTotalMax` and `commitmentsTotalMin` query params populate in the browser with the corresponding values. Query params should not populate immediately when a dropdown selection is made
- [x] When user selects a min and/or max amount and clicks "Search", capital projects list updates to only include projects for the given amounts and match other filters
- [ ] ~~When user selects a Project Type and clicks "Search", projects displayed on the map update to only include projects for the given amounts and match other filters.~~

This branch completes most of what is outlined in #158 and #159.  I am not aware of any way to do the map filtering on the front-end for Project Type, and to do the filtering on Project Amount, the API will need to be updated to output a number for the value instead of a string.  I have broken the map filtering out into new issues (#166, #167).