### PR TITLE
159 Add Project Amount filter functionality to front end

### DIFF
--- a/app/components/AdminDropdown/index.tsx
+++ b/app/components/AdminDropdown/index.tsx
@@ -72,7 +72,7 @@ export function AdminDropdown({
               boxSize={3}
               p={0.5}
               border={"1px solid"}
-              borderRadius={4}
+              borderRadius={16}
             />
           }
         />

--- a/app/components/ProjectAmountMenu/ProjectAmountMenuInput.test.tsx
+++ b/app/components/ProjectAmountMenu/ProjectAmountMenuInput.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { ProjectAmountMenuInput } from "./ProjectAmountMenuInput";
+import { act } from "react";
+
+describe("ProjectAmountMenuInput", () => {
+  const onInputValueChange = vi.fn();
+  const onSelectValueChange = vi.fn();
+  it("should render with form details", () => {
+    render(
+      <ProjectAmountMenuInput
+        label="Test Label"
+        commitmentTotalInputsAreValid={true}
+        inputValue={""}
+        selectValue=""
+        onInputValueChange={onInputValueChange}
+        onSelectValueChange={onSelectValueChange}
+      />,
+    );
+
+    expect(screen.getByText("Test Label")).toBeInTheDocument();
+  });
+
+  it("should render with default input option (blank) select option (K)", () => {
+    render(
+      <ProjectAmountMenuInput
+        label="Test Label"
+        commitmentTotalInputsAreValid={true}
+        inputValue={""}
+        selectValue=""
+        onInputValueChange={onInputValueChange}
+        onSelectValueChange={onSelectValueChange}
+      />,
+    );
+
+    const input: HTMLInputElement = screen.getByDisplayValue("");
+    expect(input).toBeInTheDocument();
+    const options: Array<HTMLOptionElement> = screen.getAllByRole("option");
+    const defaultSelect = options.find((option) => option.value === "K");
+    expect(defaultSelect).toBeInTheDocument();
+    expect(defaultSelect?.selected).toBe(true);
+  });
+
+  it("should render with a passed input option and select option", () => {
+    render(
+      <ProjectAmountMenuInput
+        label="Test Label"
+        commitmentTotalInputsAreValid={true}
+        inputValue={"123"}
+        selectValue="M"
+        onInputValueChange={onInputValueChange}
+        onSelectValueChange={onSelectValueChange}
+      />,
+    );
+
+    const input: HTMLInputElement = screen.getByDisplayValue("123");
+    expect(input).toBeInTheDocument();
+    const options: Array<HTMLOptionElement> = screen.getAllByRole("option");
+    const defaultSelect = options.find((option) => option.value === "K");
+    expect(defaultSelect).toBeInTheDocument();
+    expect(defaultSelect?.selected).toBe(false);
+    const testSelect = options.find((option) => option.value === "M");
+    expect(testSelect).toBeInTheDocument();
+    expect(testSelect?.selected).toBe(true);
+  });
+
+  it("should call input function when input is changed", async () => {
+    render(
+      <ProjectAmountMenuInput
+        label="Test Label"
+        commitmentTotalInputsAreValid={true}
+        inputValue={"123"}
+        selectValue="M"
+        onInputValueChange={onInputValueChange}
+        onSelectValueChange={onSelectValueChange}
+      />,
+    );
+
+    const input: HTMLInputElement = screen.getByDisplayValue("123");
+    await act(() => userEvent.type(input, "1"));
+    expect(onInputValueChange).toHaveBeenCalled();
+  });
+
+  it("should call select function when select is changed", async () => {
+    render(
+      <ProjectAmountMenuInput
+        label="Test Label"
+        commitmentTotalInputsAreValid={true}
+        inputValue={"123"}
+        selectValue="M"
+        onInputValueChange={onInputValueChange}
+        onSelectValueChange={onSelectValueChange}
+      />,
+    );
+
+    const options: Array<HTMLOptionElement> = screen.getAllByRole("option");
+    const millionSelect = options.find((option) => option.value === "M");
+    expect(millionSelect).toBeInTheDocument();
+    expect(millionSelect?.selected).toBe(true);
+    const billionSelect = options.find((option) => option.value === "B");
+    expect(billionSelect).toBeInTheDocument();
+    expect(billionSelect?.selected).toBe(false);
+    await act(() => userEvent.selectOptions(screen.getByRole("combobox"), "B"));
+    expect(onSelectValueChange).toHaveBeenCalled();
+  });
+});

--- a/app/components/ProjectAmountMenu/ProjectAmountMenuInput.tsx
+++ b/app/components/ProjectAmountMenu/ProjectAmountMenuInput.tsx
@@ -1,0 +1,65 @@
+import {
+  Flex,
+  Select,
+  NumberInput,
+  NumberInputField,
+} from "@nycplanning/streetscape";
+import { FormEvent } from "react";
+
+export interface ProjectAmountMenuInputProps {
+  label: string;
+  inputValue?: null | string;
+  selectValue: string;
+  commitmentTotalInputsAreValid: boolean;
+  onInputValueChange?: (value: null | string) => void;
+  onSelectValueChange?: (value: string) => void;
+}
+export function ProjectAmountMenuInput({
+  label,
+  inputValue,
+  selectValue = "K",
+  commitmentTotalInputsAreValid,
+  onInputValueChange = () => null,
+  onSelectValueChange = () => null,
+}: ProjectAmountMenuInputProps) {
+  return (
+    <Flex direction={"column"}>
+      <p
+        style={{
+          color: "var(--text-subtle)",
+          fontSize: "0.75rem",
+          letterSpacing: "0.18px",
+        }}
+      >
+        {label}
+      </p>
+      <Flex>
+        <NumberInput
+          maxWidth={"4rem"}
+          value={inputValue ?? ""}
+          isInvalid={!commitmentTotalInputsAreValid}
+        >
+          <NumberInputField
+            borderRightRadius={0}
+            onChange={(event) => onInputValueChange(event.target.value)}
+          />
+        </NumberInput>
+        <Select
+          iconSize="sm"
+          borderLeftRadius={0}
+          maxWidth={"4rem"}
+          variant="base"
+          onChange={(e: FormEvent<HTMLSelectElement>) =>
+            onSelectValueChange(e.currentTarget.value)
+          }
+          value={selectValue}
+          isInvalid={!commitmentTotalInputsAreValid}
+        >
+          <option value="K">K</option>
+          <option value="M">M</option>
+          <option value="B">B</option>
+        </Select>
+      </Flex>
+    </Flex>
+  );
+}

--- a/app/components/ProjectAmountMenu/index.test.tsx
+++ b/app/components/ProjectAmountMenu/index.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { ProjectAmountMenu } from ".";
+
+describe("ProjectAmountMenu", () => {
+  it("should render project amount label", () => {
+    render(
+      <ProjectAmountMenu
+        showClearButton={false}
+        onProjectAmountMenuClear={() => null}
+      >
+        Child Menus
+      </ProjectAmountMenu>,
+    );
+    expect(screen.getByText("Project Amount")).toBeInTheDocument();
+  });
+});

--- a/app/components/ProjectAmountMenu/index.tsx
+++ b/app/components/ProjectAmountMenu/index.tsx
@@ -1,0 +1,53 @@
+import { Flex, IconButton } from "@nycplanning/streetscape";
+import { CloseIcon } from "@chakra-ui/icons";
+import { ReactNode } from "react";
+
+export interface ProjectAmountMenuProps {
+  children: ReactNode;
+  showClearButton: boolean;
+  onProjectAmountMenuClear?: () => void;
+}
+export function ProjectAmountMenu({
+  children,
+  showClearButton,
+  onProjectAmountMenuClear = () => null,
+}: ProjectAmountMenuProps) {
+  return (
+    <>
+      <Flex width={"100%"} justifyContent={"space-between"}>
+        <h2 style={{ width: "100%", fontWeight: "500", paddingBottom: "0" }}>
+          Project Amount
+        </h2>
+        {showClearButton && (
+          <IconButton
+            aria-label={"Clear Project Amounts"}
+            variant="ghost"
+            _focus={{ borderWidth: 3, borderColor: "teal" }}
+            pos={"relative"}
+            minH={"unset"}
+            minW={"unset"}
+            height={"min-content"}
+            width={"min-content"}
+            top={2}
+            cursor={"pointer"}
+            onClick={() => {
+              onProjectAmountMenuClear();
+            }}
+            icon={
+              <CloseIcon
+                boxSize={3}
+                p={0.5}
+                border={"1px solid"}
+                borderRadius={16}
+              />
+            }
+          />
+        )}
+      </Flex>
+
+      <Flex width={"100%"} justifyContent={"space-between"}>
+        {children}
+      </Flex>
+    </>
+  );
+}

--- a/app/components/layers/useCapitalProjectsLayer.client.tsx
+++ b/app/components/layers/useCapitalProjectsLayer.client.tsx
@@ -17,6 +17,7 @@ export interface CapitalProjectProperties {
   managingCodeCapitalProjectId: string;
   managingAgency: string;
   agencyBudgets: string;
+  commitmentsTotal: number;
 }
 
 const capitalProjectsInCommunityDistrictRoutePrefix =
@@ -29,6 +30,14 @@ export function useCapitalProjectsLayer() {
   const [searchParams] = useSearchParams();
   const managingAgency = searchParams.get("managingAgency");
   const agencyBudget = searchParams.get("agencyBudget");
+  const commitmentsTotalMin = searchParams.get("commitmentsTotalMin");
+  const commitmentsTotalMax = searchParams.get("commitmentsTotalMax");
+  const min = commitmentsTotalMin
+    ? parseFloat(commitmentsTotalMin)
+    : -1000000000000;
+  const max = commitmentsTotalMax
+    ? parseFloat(commitmentsTotalMax)
+    : 1000000000000;
   const navigate = useNavigate();
 
   const matches = useMatches();
@@ -69,6 +78,9 @@ export function useCapitalProjectsLayer() {
     autoHighlight: true,
     highlightColor: [129, 230, 217, 218],
     pickable: true,
+    getFilterValue: (f: Feature<Geometry, CapitalProjectProperties>) =>
+      f.properties.commitmentsTotal,
+    filterRange: [min, max],
     getFilterCategory: (f: Feature<Geometry, CapitalProjectProperties>) => {
       const agencyBudgets = JSON.parse(f.properties.agencyBudgets);
       return [
@@ -80,7 +92,6 @@ export function useCapitalProjectsLayer() {
       managingAgency === null ? fullAgencyAcronymList : [managingAgency],
       [1],
     ],
-
     getFillColor: ({ properties }) => {
       const { managingCodeCapitalProjectId } = properties;
       switch (managingCodeCapitalProjectId) {
@@ -119,6 +130,7 @@ export function useCapitalProjectsLayer() {
     },
     extensions: [
       new DataFilterExtension({
+        filterSize: 1,
         categorySize: 2,
       }),
     ],

--- a/app/routes/boroughs.$boroughId.community-districts.$communityDistrictId.capital-projects.tsx
+++ b/app/routes/boroughs.$boroughId.community-districts.$communityDistrictId.capital-projects.tsx
@@ -17,6 +17,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const pageParam = url.searchParams.get("page");
   const managingAgency = url.searchParams.get("managingAgency");
   const agencyBudget = url.searchParams.get("agencyBudget");
+  const commitmentsTotalMin = url.searchParams.get("commitmentsTotalMin");
+  const commitmentsTotalMax = url.searchParams.get("commitmentsTotalMax");
   const page = pageParam === null ? 1 : parseInt(pageParam);
 
   const { boroughId, communityDistrictId } = params;
@@ -36,6 +38,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       offset: offset,
       ...(managingAgency === null ? {} : { managingAgency }),
       ...(agencyBudget === null ? {} : { agencyBudget }),
+      ...(commitmentsTotalMin === null ? {} : { commitmentsTotalMin }),
+      ...(commitmentsTotalMax === null ? {} : { commitmentsTotalMax }),
     },
     {
       baseURL: `${import.meta.env.VITE_ZONING_API_URL}/api`,

--- a/app/routes/capital-projects.tsx
+++ b/app/routes/capital-projects.tsx
@@ -15,6 +15,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const pageParam = url.searchParams.get("page");
   const managingAgency = url.searchParams.get("managingAgency");
   const agencyBudget = url.searchParams.get("agencyBudget");
+  const commitmentsTotalMin = url.searchParams.get("commitmentsTotalMin");
+  const commitmentsTotalMax = url.searchParams.get("commitmentsTotalMax");
   const page = pageParam === null ? 1 : parseInt(pageParam);
   if (isNaN(page)) {
     throw json("Bad Request", { status: 400 });
@@ -25,6 +27,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     {
       ...(managingAgency === null ? {} : { managingAgency }),
       ...(agencyBudget === null ? {} : { agencyBudget }),
+      ...(commitmentsTotalMin === null ? {} : { commitmentsTotalMin }),
+      ...(commitmentsTotalMax === null ? {} : { commitmentsTotalMax }),
       limit: itemsPerPage,
       offset: offset,
     },

--- a/app/routes/city-council-districts.$cityCouncilDistrictId.capital-projects.tsx
+++ b/app/routes/city-council-districts.$cityCouncilDistrictId.capital-projects.tsx
@@ -12,6 +12,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const pageParam = url.searchParams.get("page");
   const managingAgency = url.searchParams.get("managingAgency");
   const agencyBudget = url.searchParams.get("agencyBudget");
+  const commitmentsTotalMin = url.searchParams.get("commitmentsTotalMin");
+  const commitmentsTotalMax = url.searchParams.get("commitmentsTotalMax");
   const page = pageParam === null ? 1 : parseInt(pageParam);
   const { cityCouncilDistrictId } = params;
   if (cityCouncilDistrictId === undefined || isNaN(page)) {
@@ -26,6 +28,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       offset: offset,
       ...(managingAgency === null ? {} : { managingAgency }),
       ...(agencyBudget === null ? {} : { agencyBudget }),
+      ...(commitmentsTotalMin === null ? {} : { commitmentsTotalMin }),
+      ...(commitmentsTotalMax === null ? {} : { commitmentsTotalMax }),
     },
     {
       baseURL: `${import.meta.env.VITE_ZONING_API_URL}/api`,

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -3,6 +3,13 @@ export type DistrictType = null | "cd" | "ccd";
 export type DistrictId = null | string;
 export type ManagingAgencyAcronym = null | string;
 export type AgencyBudgetType = null | string;
+export type CommitmentsTotalMin = null | string;
+export type CommitmentsTotalMax = null | string;
+export type CommitmentsTotalMinInputValue = string;
+export type CommitmentsTotalMinSelectValue = string;
+export type CommitmentsTotalMaxInputValue = string;
+export type CommitmentsTotalMaxSelectValue = string;
+export type CommitmentTotalInputsAreValid = boolean;
 
 export type AdminParams = {
   districtType: DistrictType;
@@ -13,6 +20,16 @@ export type AdminParams = {
 export type AttributeParams = {
   managingAgency: ManagingAgencyAcronym;
   agencyBudget: AgencyBudgetType;
+  commitmentsTotalMin: CommitmentsTotalMin;
+  commitmentsTotalMax: CommitmentsTotalMax;
+};
+
+export type ProjectAmountMenuParams = {
+  commitmentsTotalMinInputValue: CommitmentsTotalMinInputValue;
+  commitmentsTotalMinSelectValue: CommitmentsTotalMinSelectValue;
+  commitmentsTotalMaxInputValue: CommitmentsTotalMaxInputValue;
+  commitmentsTotalMaxSelectValue: CommitmentsTotalMaxSelectValue;
+  commitmentTotalInputsAreValid: CommitmentTotalInputsAreValid;
 };
 
 export type SearchParamChanges = Record<

--- a/app/utils/utils.test.ts
+++ b/app/utils/utils.test.ts
@@ -1,0 +1,230 @@
+import {
+  handleCommitmentTotalsInputs,
+  checkCommitmentTotalInputsAreValid,
+} from "./utils";
+
+describe("handleCommitmentTotalsInputs", () => {
+  it("should return the defaults when passed null min and max", async () => {
+    const result = handleCommitmentTotalsInputs(null, null);
+    expect(result.commitmentsTotalMinInputValue === "").toBe(true);
+    expect(result.commitmentsTotalMaxInputValue === "").toBe(true);
+    expect(result.commitmentsTotalMinSelectValue === "K").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "K").toBe(true);
+  });
+
+  it("should return the defaults when passed an empty string for min and max", async () => {
+    const result = handleCommitmentTotalsInputs("", "");
+    expect(result.commitmentsTotalMinInputValue === "").toBe(true);
+    expect(result.commitmentsTotalMaxInputValue === "").toBe(true);
+    expect(result.commitmentsTotalMinSelectValue === "K").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "K").toBe(true);
+  });
+
+  it("should return the defaults when passed 0 min and max", async () => {
+    const result = handleCommitmentTotalsInputs("0", "0");
+    expect(result.commitmentsTotalMinInputValue === "").toBe(true);
+    expect(result.commitmentsTotalMaxInputValue === "").toBe(true);
+    expect(result.commitmentsTotalMinSelectValue === "K").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "K").toBe(true);
+  });
+
+  it("should return the defaults when passed values between 0 and 1000", async () => {
+    const result = handleCommitmentTotalsInputs("1", "999.9999");
+    expect(result.commitmentsTotalMinInputValue === "").toBe(true);
+    expect(result.commitmentsTotalMaxInputValue === "").toBe(true);
+    expect(result.commitmentsTotalMinSelectValue === "K").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "K").toBe(true);
+  });
+
+  it("should return the defaults when passed values between -1000 and 0", async () => {
+    const result = handleCommitmentTotalsInputs("-999.9999", "-1");
+    expect(result.commitmentsTotalMinInputValue === "").toBe(true);
+    expect(result.commitmentsTotalMaxInputValue === "").toBe(true);
+    expect(result.commitmentsTotalMinSelectValue === "K").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "K").toBe(true);
+  });
+
+  it("should return the correct values when passed values between 1000 and 1000000", async () => {
+    const result = handleCommitmentTotalsInputs("2000", "12345.67");
+    expect(result.commitmentsTotalMinInputValue === "2").toBe(true);
+    expect(result.commitmentsTotalMaxInputValue === "12.34567").toBe(true);
+    expect(result.commitmentsTotalMinSelectValue === "K").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "K").toBe(true);
+  });
+
+  it("should return the correct values when passed values between -1000000 and -1000", async () => {
+    const result = handleCommitmentTotalsInputs("-12345.67", "-2000");
+    expect(result.commitmentsTotalMinInputValue === "-12.34567").toBe(true);
+    expect(result.commitmentsTotalMaxInputValue === "-2").toBe(true);
+    expect(result.commitmentsTotalMinSelectValue === "K").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "K").toBe(true);
+  });
+
+  it("should return the correct values when passed values between 1000000 and 1000000000", async () => {
+    const result = handleCommitmentTotalsInputs("2000000", "12345678");
+    expect(result.commitmentsTotalMinInputValue === "2").toBe(true);
+    expect(result.commitmentsTotalMaxInputValue === "12.345678").toBe(true);
+    expect(result.commitmentsTotalMinSelectValue === "M").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "M").toBe(true);
+  });
+
+  it("should return the correct values when passed values between -1000000000 and -1000000", async () => {
+    const result = handleCommitmentTotalsInputs("-12345678", "-2000000");
+    expect(result.commitmentsTotalMinInputValue === "-12.345678").toBe(true);
+    expect(result.commitmentsTotalMaxInputValue === "-2").toBe(true);
+    expect(result.commitmentsTotalMinSelectValue === "M").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "M").toBe(true);
+  });
+
+  it("should return the correct values when passed values greater than 1000000000", async () => {
+    const result = handleCommitmentTotalsInputs("2000000000", "123456780000");
+    expect(result.commitmentsTotalMinInputValue === "2").toBe(true);
+    expect(result.commitmentsTotalMaxInputValue === "123.45678").toBe(true);
+    expect(result.commitmentsTotalMinSelectValue === "B").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "B").toBe(true);
+  });
+
+  it("should return the correct values when passed values less than -1000000000", async () => {
+    const result = handleCommitmentTotalsInputs("-123456780000", "-2000000000");
+    expect(result.commitmentsTotalMinInputValue === "-123.45678").toBe(true);
+    expect(result.commitmentsTotalMaxInputValue === "-2").toBe(true);
+    expect(result.commitmentsTotalMinSelectValue === "B").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "B").toBe(true);
+  });
+
+  it("should return the incorrect input values when passed some values with decimals due to JS float issues", async () => {
+    const result = handleCommitmentTotalsInputs("1234.56", "12345.6789");
+    expect(result.commitmentsTotalMinInputValue === "1.23456").toBe(false);
+    expect(result.commitmentsTotalMinInputValue === "1.2345599999999999").toBe(
+      true,
+    );
+    expect(result.commitmentsTotalMaxInputValue === "12.3456789").toBe(false);
+    expect(result.commitmentsTotalMaxInputValue === "12.345678900000001").toBe(
+      true,
+    );
+    expect(result.commitmentsTotalMinSelectValue === "K").toBe(true);
+    expect(result.commitmentsTotalMaxSelectValue === "K").toBe(true);
+  });
+});
+
+describe("checkCommitmentTotalInputsAreValid", () => {
+  it("should return true for default state", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "",
+      commitmentsTotalMaxInputValue: "",
+      commitmentsTotalMinSelectValue: "K",
+      commitmentsTotalMaxSelectValue: "K",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should return true when select values have changed and inputs are blank", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "",
+      commitmentsTotalMaxInputValue: "",
+      commitmentsTotalMinSelectValue: "B",
+      commitmentsTotalMaxSelectValue: "M",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should return true when only a minimum has been input", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "1",
+      commitmentsTotalMaxInputValue: "",
+      commitmentsTotalMinSelectValue: "K",
+      commitmentsTotalMaxSelectValue: "K",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should return true when only a maximum has been input", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "",
+      commitmentsTotalMaxInputValue: "1",
+      commitmentsTotalMinSelectValue: "K",
+      commitmentsTotalMaxSelectValue: "K",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should return true when MinInput < MaxInput and MinSelect = MaxSelect", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "1",
+      commitmentsTotalMaxInputValue: "2",
+      commitmentsTotalMinSelectValue: "K",
+      commitmentsTotalMaxSelectValue: "K",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should return false when MinInput > MaxInput and MinSelect = MaxSelect", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "2",
+      commitmentsTotalMaxInputValue: "1",
+      commitmentsTotalMinSelectValue: "K",
+      commitmentsTotalMaxSelectValue: "K",
+    });
+    expect(result).toBe(false);
+  });
+
+  it("should return true when MinInput = MaxInput and MinSelect '<' MaxSelect", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "1",
+      commitmentsTotalMaxInputValue: "1",
+      commitmentsTotalMinSelectValue: "K",
+      commitmentsTotalMaxSelectValue: "M",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should return false when MinInput = MaxInput and MinSelect '>' MaxSelect", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "1",
+      commitmentsTotalMaxInputValue: "1",
+      commitmentsTotalMinSelectValue: "M",
+      commitmentsTotalMaxSelectValue: "K",
+    });
+    expect(result).toBe(false);
+  });
+
+  it("should return true when MinInput < MaxInput, both are negative, and MinSelect = MaxSelect", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "-2",
+      commitmentsTotalMaxInputValue: "-1",
+      commitmentsTotalMinSelectValue: "K",
+      commitmentsTotalMaxSelectValue: "K",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should return false when MinInput > MaxInput, both are negative, and MinSelect = MaxSelect", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "-1",
+      commitmentsTotalMaxInputValue: "-2",
+      commitmentsTotalMinSelectValue: "K",
+      commitmentsTotalMaxSelectValue: "K",
+    });
+    expect(result).toBe(false);
+  });
+
+  it("should return true when MinInput < MaxInput and MinInput is negative", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "-200",
+      commitmentsTotalMaxInputValue: "1",
+      commitmentsTotalMinSelectValue: "B",
+      commitmentsTotalMaxSelectValue: "K",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should return true when MinInput > MaxInput and MaxInput is negative", async () => {
+    const result = checkCommitmentTotalInputsAreValid({
+      commitmentsTotalMinInputValue: "200",
+      commitmentsTotalMaxInputValue: "-1",
+      commitmentsTotalMinSelectValue: "B",
+      commitmentsTotalMaxSelectValue: "K",
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -1,5 +1,13 @@
 import { compareAsc, format, getMonth, getYear } from "date-fns";
-import { SearchParamChanges } from "./types";
+import {
+  SearchParamChanges,
+  CommitmentsTotalMin,
+  CommitmentsTotalMax,
+  CommitmentsTotalMinInputValue,
+  CommitmentsTotalMaxInputValue,
+  CommitmentsTotalMinSelectValue,
+  CommitmentsTotalMaxSelectValue,
+} from "./types";
 
 const getFiscalYearForDate = (date: Date): number => {
   const year = getYear(date);
@@ -15,6 +23,95 @@ export const formatFiscalYearRange = (minDate: Date, maxDate: Date) => {
 
 export const currentDate = () => {
   return `${format(new Date(), "MM/dd/yyyy")}`;
+};
+
+export const handleCommitmentTotalsInputs = (
+  commitmentsTotalMin: CommitmentsTotalMin,
+  commitmentsTotalMax: CommitmentsTotalMax,
+) => {
+  let commitmentsTotalMinInputValue = "" as CommitmentsTotalMinInputValue;
+  let commitmentsTotalMaxInputValue = "" as CommitmentsTotalMaxInputValue;
+  let commitmentsTotalMinSelectValue = "K" as CommitmentsTotalMinSelectValue;
+  let commitmentsTotalMaxSelectValue = "K" as CommitmentsTotalMaxSelectValue;
+  if (commitmentsTotalMin && parseFloat(commitmentsTotalMin)) {
+    if (Math.abs(parseFloat(commitmentsTotalMin)) >= 1000000000) {
+      commitmentsTotalMinInputValue = (
+        parseFloat(commitmentsTotalMin) / 1000000000
+      ).toString();
+      commitmentsTotalMinSelectValue = "B";
+    } else if (Math.abs(parseFloat(commitmentsTotalMin)) >= 1000000) {
+      commitmentsTotalMinInputValue = (
+        parseFloat(commitmentsTotalMin) / 1000000
+      ).toString();
+      commitmentsTotalMinSelectValue = "M";
+    } else if (Math.abs(parseFloat(commitmentsTotalMin)) >= 1000) {
+      commitmentsTotalMinInputValue = (
+        parseFloat(commitmentsTotalMin) / 1000
+      ).toString();
+    }
+  }
+  if (commitmentsTotalMax && parseFloat(commitmentsTotalMax)) {
+    if (Math.abs(parseFloat(commitmentsTotalMax)) >= 1000000000) {
+      commitmentsTotalMaxInputValue = (
+        parseFloat(commitmentsTotalMax) / 1000000000
+      ).toString();
+      commitmentsTotalMaxSelectValue = "B";
+    } else if (Math.abs(parseFloat(commitmentsTotalMax)) >= 1000000) {
+      commitmentsTotalMaxInputValue = (
+        parseFloat(commitmentsTotalMax) / 1000000
+      ).toString();
+      commitmentsTotalMaxSelectValue = "M";
+    } else if (Math.abs(parseFloat(commitmentsTotalMax)) >= 1000) {
+      commitmentsTotalMaxInputValue = (
+        parseFloat(commitmentsTotalMax) / 1000
+      ).toString();
+    }
+  }
+
+  return {
+    commitmentsTotalMinInputValue,
+    commitmentsTotalMinSelectValue,
+    commitmentsTotalMaxInputValue,
+    commitmentsTotalMaxSelectValue,
+  };
+};
+
+export function getMultiplier(multiplier: string) {
+  switch (multiplier) {
+    case "B":
+      return 1000000000;
+    case "M":
+      return 1000000;
+    case "K":
+      return 1000;
+    default:
+      return 1;
+  }
+}
+
+export interface CheckCommitmentTotalInputsAreValidProps {
+  commitmentsTotalMinInputValue: CommitmentsTotalMinInputValue;
+  commitmentsTotalMaxInputValue: CommitmentsTotalMaxInputValue;
+  commitmentsTotalMinSelectValue: CommitmentsTotalMinSelectValue;
+  commitmentsTotalMaxSelectValue: CommitmentsTotalMaxSelectValue;
+}
+
+export const checkCommitmentTotalInputsAreValid = ({
+  commitmentsTotalMinInputValue,
+  commitmentsTotalMaxInputValue,
+  commitmentsTotalMinSelectValue,
+  commitmentsTotalMaxSelectValue,
+}: CheckCommitmentTotalInputsAreValidProps) => {
+  if (!commitmentsTotalMinInputValue || !commitmentsTotalMaxInputValue)
+    return true;
+  const min =
+    parseFloat(commitmentsTotalMinInputValue) *
+    getMultiplier(commitmentsTotalMinSelectValue);
+  const max =
+    parseFloat(commitmentsTotalMaxInputValue) *
+    getMultiplier(commitmentsTotalMaxSelectValue);
+  if (min <= max) return true;
+  return false;
 };
 
 // from https://www.jacobparis.com/content/remix-pagination

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.11.0",
         "@kubb/swagger-client": "^2.28.3",
-        "@nycplanning/streetscape": "^0.12.0",
+        "@nycplanning/streetscape": "^0.14.1",
         "@remix-run/node": "^2.13.1",
         "@remix-run/react": "^2.13.1",
         "@remix-run/serve": "^2.13.1",
@@ -5114,9 +5114,9 @@
       }
     },
     "node_modules/@nycplanning/streetscape": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@nycplanning/streetscape/-/streetscape-0.12.0.tgz",
-      "integrity": "sha512-OuIxO2edUufjotYV7IRE5cmDZ/GN5eT5XIHvSX2IgDG7MDyNv7UmLERovfGSzin87DCnq3eTp+h3BGI08gvsvw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@nycplanning/streetscape/-/streetscape-0.14.1.tgz",
+      "integrity": "sha512-+Q7vqSISxrjbyH3RDnxQDoREiwaaWRkhGnnwL+T1CQZKKxHLbyYHjtWD8Obh9TGlbw1dFdZLmH1BLo4NG6HxOg==",
       "hasInstallScript": true,
       "dependencies": {
         "@chakra-ui/cli": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@kubb/swagger-client": "^2.28.3",
-    "@nycplanning/streetscape": "^0.12.0",
+    "@nycplanning/streetscape": "^0.14.1",
     "@remix-run/node": "^2.13.1",
     "@remix-run/react": "^2.13.1",
     "@remix-run/serve": "^2.13.1",


### PR DESCRIPTION
## Acceptance Criteria

- [x] Add new Project Amount filter to "Search by Attribute" menu ([designs](https://www.figma.com/design/LYHHoPop9l0jpEivk5CFzJ/Capital-Projects-Portal?node-id=3040-8347&t=6DJJiMHdTYgBMpyB-0))
- [x] Min and Max filters have dropdowns for "K", "M", and "B" for thousands, millions, billions.
- [x] When user selects a min and/or max project amount and clicks "Search", new `commitmentsTotalMax` and `commitmentsTotalMin` query params populate in the browser with the corresponding values. Query params should not populate immediately when a dropdown selection is made
- [x] When user selects a min and/or max amount and clicks "Search", capital projects list updates to only include projects for the given amounts and match other filters
- [x] When user selects a Project Type and clicks "Search", projects displayed on the map update to only include projects for the given amounts and match other filters.

## Depends on:
* https://github.com/NYCPlanning/ae-zoning-api/issues/426
* https://github.com/NYCPlanning/ae-zoning-api/issues/399

Closes #159