### PR TITLE
181 Update pagination UI

### DIFF
--- a/app/components/CapitalProjectsList/CapitalProjectsList.tsx
+++ b/app/components/CapitalProjectsList/CapitalProjectsList.tsx
@@ -46,28 +46,23 @@ export const CapitalProjectsList = ({
     );
   }
 
-  const listBody =
-    capitalProjects.length === 0 ? (
-      <Text>Reached end of projects</Text>
-    ) : (
-      capitalProjects.map((capitalProject) => {
-        return (
-          <CapitalProjectsListItem
-            key={`${capitalProject.managingCode}${capitalProject.id}`}
-            capitalProject={capitalProject as CapitalProjectBudgeted}
-            agency={
-              agencies.find(
-                (agency) => agency.initials === capitalProject.managingAgency,
-              )?.name
-            }
-            yearRange={formatFiscalYearRange(
-              new Date(capitalProject.minDate),
-              new Date(capitalProject.maxDate),
-            )}
-          />
-        );
-      })
+  const listBody = capitalProjects.map((capitalProject) => {
+    return (
+      <CapitalProjectsListItem
+        key={`${capitalProject.managingCode}${capitalProject.id}`}
+        capitalProject={capitalProject as CapitalProjectBudgeted}
+        agency={
+          agencies.find(
+            (agency) => agency.initials === capitalProject.managingAgency,
+          )?.name
+        }
+        yearRange={formatFiscalYearRange(
+          new Date(capitalProject.minDate),
+          new Date(capitalProject.maxDate),
+        )}
+      />
     );
+  });
 
   return (
     <>

--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
-import { Box, HStack } from "@nycplanning/streetscape";
+import { Box, HStack, Text } from "@nycplanning/streetscape";
 import { Link, useSearchParams } from "@remix-run/react";
 import { setNewSearchParams } from "~/utils/utils";
 import { analytics } from "~/utils/analytics";
@@ -14,24 +14,25 @@ export const Pagination = ({ total }: PaginationProps) => {
   const pageParam = searchParams.get("page");
   const page = pageParam === null ? 1 : parseInt(pageParam);
   const canSkipBackward = page > 1;
-  const canSkipForward = total === itemsPerPage;
+  const totalPages = Math.ceil(total / itemsPerPage);
+  const canSkipForward = page < totalPages;
 
   return (
-    <HStack gap={2}>
+    <HStack gap={1} alignContent={"baseline"}>
       <Link
         to={{
           search: setNewSearchParams(searchParams, {
             page: page - 1,
           }).toString(),
         }}
-        onClick={() =>
+        onClick={() => {
           analytics({
             category: "Pagination",
             action: "Click",
             name: "Back",
             value: page - 1,
-          })
-        }
+          });
+        }}
       >
         <Box
           as="button"
@@ -43,19 +44,15 @@ export const Pagination = ({ total }: PaginationProps) => {
           <ChevronLeftIcon />
         </Box>
       </Link>
-      <Box
-        borderRadius={2}
-        height={"2rem"}
-        width={"2rem"}
-        fontSize="sm"
-        aria-label={`Page ${page}`}
-        bgColor={"primary.600"}
-        textColor={"white"}
-        alignContent={"center"}
-        textAlign={"center"}
+      <Text
+        fontSize="xs"
+        aria-label={`Page ${page} of ${totalPages}`}
+        textColor={"gray.600"}
+        fontWeight={700}
+        paddingTop={1}
       >
-        {page}
-      </Box>
+        {page} of {totalPages}
+      </Text>
       <Link
         to={{
           search: setNewSearchParams(searchParams, {


### PR DESCRIPTION
This issue is to update the project list pagination UI to match the [Additional Filter designs](https://www.figma.com/design/LYHHoPop9l0jpEivk5CFzJ/Capital-Projects-Portal?node-id=4308-44267&m=dev)

# Acceptance Criteria

- [x] Previous page button is disabled if on first page
- [x] Next page button is disabled if on last page
- [x] Add "1 of 10" text - 1 being current page, 10 total number of pages.
- [x] Do not add "Results: 1 - 7 of xyz" text - to be added as part of #180 
- [x] Remove "Reached end of projects" text. With new pagination functionality, users should never reach an empty page of projects.

Closes #181 