### PR TITLE
247 Refactor routing and nested layout components

### DIFF
--- a/app/components/atlas.client.tsx
+++ b/app/components/atlas.client.tsx
@@ -99,7 +99,9 @@ export function Atlas({
         });
       }}
       controller={true}
-      style={{ height: "100vh", width: "100vw" }}
+      style={{
+        position: "relative",
+      }}
       layers={[
         capitalProjectsLayer,
         capitalProjectBudgetedGeoJsonLayer,

--- a/app/components/layers/useCapitalProjectsLayer.client.tsx
+++ b/app/components/layers/useCapitalProjectsLayer.client.tsx
@@ -17,8 +17,8 @@ import {
   CommitmentsTotalMin,
   CommitmentsTotalMax,
 } from "../../utils/types";
-import { loader as rootLoader } from "~/root";
 import { env } from "~/utils/env";
+import { loader as mapPageLoader } from "~/layouts/MapPage";
 
 const { zoningApiUrl } = env;
 export interface CapitalProjectProperties {
@@ -63,7 +63,7 @@ export function useCapitalProjectsLayer(opts?: { visible?: boolean }) {
     endpointPrefix = `boroughs/${boroughId}/community-districts/${districtId}/`;
   }
 
-  const loaderData = useLoaderData<typeof rootLoader>();
+  const loaderData = useLoaderData<typeof mapPageLoader>();
 
   const fullAgencyAcronymList = loaderData.managingAgencies
     ? loaderData.managingAgencies.map((agency) => agency.initials)

--- a/app/layouts/MapPage.tsx
+++ b/app/layouts/MapPage.tsx
@@ -1,0 +1,242 @@
+import { Flex, GridItem, Accordion, Box } from "@nycplanning/streetscape";
+import {
+  Outlet,
+  useLoaderData,
+  useOutletContext,
+  LoaderFunctionArgs,
+} from "react-router";
+import { Atlas } from "../components/atlas.client";
+import {
+  findBoroughs,
+  findCityCouncilDistricts,
+  findCommunityDistrictsByBoroughId,
+  findAgencyBudgets,
+  findCapitalProjectManagingAgencies,
+} from "../gen";
+import { FilterMenu } from "../components/FilterMenu";
+import { SearchByAttributeMenu } from "../components/SearchByAttributeMenu";
+import { env } from "../utils/env";
+import { BoroughId, DistrictType } from "../utils/types";
+import { HowToUseThisTool } from "../components/AdminDropdownContent/HowToUseThisTool";
+import { MapLayersPanel } from "../components/AdminMapLayersPanel";
+import {
+  CapitalProjectLayerToggle,
+  CommunityBoardBudgetRequestLayerToggle,
+} from "~/components/MapLayerToggle";
+import { CommunityBoardBudgetRequestLegend } from "../components/CommunityBoardBudgetRequestLegend";
+import { useUpdateSearchParams } from "../utils/utils";
+import type { RootContextType } from "../root";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const districtType = url.searchParams.get("districtType") as DistrictType;
+  const boroughId = url.searchParams.get("boroughId") as BoroughId;
+
+  const { managingAgencies } = await findCapitalProjectManagingAgencies({
+    baseURL: `${env.zoningApiUrl}/api`,
+  });
+
+  const { agencyBudgets } = await findAgencyBudgets({
+    baseURL: `${env.zoningApiUrl}/api`,
+  });
+
+  if (districtType === "cd") {
+    const { boroughs } = await findBoroughs({
+      baseURL: `${env.zoningApiUrl}/api`,
+    });
+
+    if (boroughId === null) {
+      return {
+        boroughs,
+        communityDistricts: null,
+        cityCouncilDistricts: null,
+        managingAgencies,
+        agencyBudgets,
+      };
+    } else {
+      const { communityDistricts } = await findCommunityDistrictsByBoroughId(
+        boroughId,
+        {
+          baseURL: `${env.zoningApiUrl}/api`,
+        },
+      );
+
+      return {
+        boroughs,
+        communityDistricts,
+        cityCouncilDistricts: null,
+        managingAgencies,
+        agencyBudgets,
+      };
+    }
+  }
+
+  if (districtType === "ccd") {
+    const { cityCouncilDistricts } = await findCityCouncilDistricts({
+      baseURL: `${env.zoningApiUrl}/api`,
+    });
+    return {
+      boroughs: null,
+      communityDistricts: null,
+      cityCouncilDistricts,
+      managingAgencies,
+      agencyBudgets,
+    };
+  }
+
+  return {
+    boroughs: null,
+    communityDistricts: null,
+    cityCouncilDistricts: null,
+    managingAgencies,
+    agencyBudgets,
+  };
+};
+
+export default function MapPage() {
+  const { viewState, setViewState } = useOutletContext<RootContextType>();
+  const [searchParams, updateSearchParams] = useUpdateSearchParams();
+  const showCapitalProjects = searchParams.get("capitalProjects") !== "off";
+  const showCbbr = searchParams.get("cbbr") !== "off";
+
+  const {
+    boroughs,
+    communityDistricts,
+    cityCouncilDistricts,
+    managingAgencies,
+    agencyBudgets,
+  } = useLoaderData<typeof loader>();
+
+  const clearCapitalProjectFilters = () => {
+    updateSearchParams({
+      managingAgency: null,
+      agencyBudget: null,
+      commitmentsTotalMin: null,
+      commitmentsTotalMax: null,
+    });
+  };
+
+  return (
+    <>
+      <GridItem
+        gridColumn={"1 / -1"}
+        gridRow={{
+          base: "2 / 5",
+          md: "2 / -1",
+        }}
+      >
+        <Atlas
+          viewState={viewState}
+          setViewState={(MapViewState) => setViewState(MapViewState)}
+          showCapitalProjects={showCapitalProjects}
+          showCbbr={showCbbr}
+        />{" "}
+      </GridItem>
+      <GridItem
+        gridColumn={{
+          base: "col-start / span 7",
+          md: "col-start / span 4",
+          xl: "col-start / span 3",
+          "2xl": "col-start / span 2",
+        }}
+        gridRow={{
+          base: "row-start / row-end",
+          md: "row-start / row-end",
+          lg: "row-start / span 1",
+        }}
+        height={"100%"}
+        overflowY={{ lg: "scroll" }}
+        zIndex={"1"}
+        sx={{
+          scrollbarWidth: "none",
+        }}
+      >
+        <Flex
+          direction={"column"}
+          width={{ base: "100%", lg: "auto" }}
+          alignItems={"center"}
+          flexShrink={{ lg: 0 }}
+          maxHeight={{
+            base: "82vh",
+            lg: "full",
+          }}
+          backgroundColor={"white"}
+          borderRadius={10}
+          overflowY={"scroll"}
+          padding={4}
+          sx={{
+            scrollbarWidth: "none",
+          }}
+          boxShadow={"0 2px 8px 0 rgba(0, 0, 0, 0.20)"}
+        >
+          <Accordion allowMultiple defaultIndex={[0]} width={"100%"}>
+            <MapLayersPanel>
+              <Box display={"flex"} flexDirection={"column"} gap={2}>
+                <CapitalProjectLayerToggle />
+                <SearchByAttributeMenu
+                  agencies={managingAgencies}
+                  projectTypes={agencyBudgets}
+                  onClear={clearCapitalProjectFilters}
+                />
+                <CommunityBoardBudgetRequestLayerToggle />
+                <CommunityBoardBudgetRequestLegend />
+              </Box>
+            </MapLayersPanel>
+            <FilterMenu
+              boroughs={boroughs}
+              communityDistricts={communityDistricts}
+              cityCouncilDistricts={cityCouncilDistricts}
+            />
+            <HowToUseThisTool />
+          </Accordion>
+        </Flex>
+      </GridItem>
+      <GridItem
+        gridColumn={{
+          base: "1 / -1",
+          md: "9 / span 5",
+          xl: "10 / col-end",
+          "2xl": "11 / col-end",
+        }}
+        gridRow={{
+          base: "3 / -1",
+          md: "row-start / row-end",
+          lg: "row-start / span 1",
+        }}
+        height={"100%"}
+        pointerEvents={"none"}
+        zIndex={"2"}
+        sx={{
+          scrollbarWidth: "none",
+        }}
+        overflowY={"scroll"}
+        display={"flex"}
+        flexDirection={"column"}
+        justifyContent={{ base: "end", md: "start" }}
+      >
+        <Flex
+          width={"full"}
+          gap={3}
+          pointerEvents={"none"}
+          sx={{
+            "> *": {
+              pointerEvents: "auto",
+            },
+            scrollbarWidth: "none",
+          }}
+          direction={"column"}
+          flexShrink={{ lg: 0 }}
+          maxHeight={"full"}
+          justify={"end"}
+          backgroundColor={"white"}
+          borderRadius={10}
+          overflowY={"scroll"}
+          padding={4}
+          boxShadow={"0 8px 4px 0 rgba(0, 0, 0, 0.08)"}
+        >
+          <Outlet />
+        </Flex>
+      </GridItem>
+    </>
+  );
+}

--- a/app/layouts/NonMapPage.tsx
+++ b/app/layouts/NonMapPage.tsx
@@ -1,0 +1,76 @@
+import { Grid, GridItem, Text, VStack, Link } from "@nycplanning/streetscape";
+import { Outlet } from "react-router";
+
+export default function NonMapHeaderPage() {
+  return (
+    <Grid
+      templateColumns={"subgrid"}
+      templateRows={"subgrid"}
+      gridColumn={"1 / -1"}
+      gridRow={"2 / -1"}
+    >
+      <GridItem
+        gridColumnStart={{
+          base: "2",
+          lg: "3",
+          xl: "4",
+        }}
+        gridColumnEnd={{
+          base: "-2",
+          lg: "10",
+          xl: "9",
+        }}
+        gridRowStart={"2"}
+        gridRowEnd={"3"}
+        pt={8}
+      >
+        <Outlet />
+      </GridItem>
+      <GridItem
+        gridColumnStart={{
+          base: "2",
+          lg: "10",
+          xl: "9",
+        }}
+        gridColumnEnd={{
+          base: "-2",
+          lg: "12",
+          xl: "12",
+        }}
+        gridRowStart={{
+          base: "3",
+          lg: "2",
+        }}
+        gridRowEnd={{
+          base: "4",
+          lg: "3",
+        }}
+        pt={8}
+      >
+        <VStack
+          alignItems={"flex-start"}
+          py={{
+            base: 9,
+            lg: 0,
+          }}
+        >
+          <Text color={"gray.700"} fontWeight={"bold"}>
+            Feedback
+          </Text>
+          <Text>
+            This tool is in active development and DCP is open to any and all
+            feedback. For questions, inquires or feedback on CPP or its content,
+            please send us an email.
+          </Text>
+          <Link
+            href="mailto:CAPS@planning.nyc.gov"
+            color={"primary.600"}
+            textDecorationLine={"underline"}
+          >
+            Email CAPS@planning.nyc.gov
+          </Link>
+        </VStack>
+      </GridItem>
+    </Grid>
+  );
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -2,10 +2,7 @@ import {
   StreetscapeProvider,
   Box,
   Heading,
-  Flex,
   Grid,
-  GridItem,
-  Accordion,
 } from "@nycplanning/streetscape";
 import {
   Links,
@@ -14,43 +11,19 @@ import {
   Scripts,
   ScrollRestoration,
   isRouteErrorResponse,
-  useLoaderData,
-  useLocation,
   useRouteError,
-  useSearchParams,
-  LoaderFunctionArgs,
   LinksFunction,
+  useSearchParams,
 } from "react-router";
-import { Atlas, INITIAL_VIEW_STATE } from "./components/atlas.client";
+import { FlyToInterpolator, MapViewState } from "@deck.gl/core";
 import { ClientOnly } from "remix-utils/client-only";
-
-import {
-  findBoroughs,
-  findCityCouncilDistricts,
-  findCommunityDistrictsByBoroughId,
-  findAgencyBudgets,
-  findCapitalProjectManagingAgencies,
-} from "./gen";
-import { FilterMenu } from "./components/FilterMenu";
-import { SearchByAttributeMenu } from "./components/SearchByAttributeMenu";
 import { useEffect, useState } from "react";
 import {
   initializeMatomoTagManager,
   initFullStoryAnalytics,
 } from "./utils/analytics";
-import { env } from "./utils/env";
-import { BoroughId, DistrictType } from "./utils/types";
-import { FlyToInterpolator, MapViewState } from "@deck.gl/core";
 import { HeaderBar } from "./components/HeaderBar";
-import { HowToUseThisTool } from "./components/AdminDropdownContent/HowToUseThisTool";
-import { MapLayersPanel } from "./components/AdminMapLayersPanel";
-import About from "./routes/about";
-import { useUpdateSearchParams } from "./utils/utils";
-import { CommunityBoardBudgetRequestLegend } from "./components/CommunityBoardBudgetRequestLegend";
-import {
-  CapitalProjectLayerToggle,
-  CommunityBoardBudgetRequestLayerToggle,
-} from "./components/MapLayerToggle";
+import { INITIAL_VIEW_STATE } from "./components/atlas.client";
 
 export const links: LinksFunction = () => {
   return [
@@ -60,74 +33,6 @@ export const links: LinksFunction = () => {
       type: "image/x-icon",
     },
   ];
-};
-
-const { zoningApiUrl } = env;
-
-export const loader = async ({ request }: LoaderFunctionArgs) => {
-  const url = new URL(request.url);
-  const districtType = url.searchParams.get("districtType") as DistrictType;
-  const boroughId = url.searchParams.get("boroughId") as BoroughId;
-
-  const { managingAgencies } = await findCapitalProjectManagingAgencies({
-    baseURL: `${zoningApiUrl}/api`,
-  });
-
-  const { agencyBudgets } = await findAgencyBudgets({
-    baseURL: `${zoningApiUrl}/api`,
-  });
-
-  if (districtType === "cd") {
-    const { boroughs } = await findBoroughs({
-      baseURL: `${zoningApiUrl}/api`,
-    });
-
-    if (boroughId === null) {
-      return {
-        boroughs,
-        communityDistricts: null,
-        cityCouncilDistricts: null,
-        managingAgencies,
-        agencyBudgets,
-      };
-    } else {
-      const { communityDistricts } = await findCommunityDistrictsByBoroughId(
-        boroughId,
-        {
-          baseURL: `${zoningApiUrl}/api`,
-        },
-      );
-
-      return {
-        boroughs,
-        communityDistricts,
-        cityCouncilDistricts: null,
-        managingAgencies,
-        agencyBudgets,
-      };
-    }
-  }
-
-  if (districtType === "ccd") {
-    const { cityCouncilDistricts } = await findCityCouncilDistricts({
-      baseURL: `${zoningApiUrl}/api`,
-    });
-    return {
-      boroughs: null,
-      communityDistricts: null,
-      cityCouncilDistricts,
-      managingAgencies,
-      agencyBudgets,
-    };
-  }
-
-  return {
-    boroughs: null,
-    communityDistricts: null,
-    cityCouncilDistricts: null,
-    managingAgencies,
-    agencyBudgets,
-  };
 };
 
 function Document({
@@ -160,24 +65,18 @@ function Document({
   );
 }
 
+export type RootContextType = {
+  viewState: MapViewState;
+  setViewState: (newViewState: MapViewState) => void;
+};
+
 export default function App() {
   useEffect(() => {
     initializeMatomoTagManager("SmoWWpiD");
     initFullStoryAnalytics();
   }, []);
   const [viewState, setViewState] = useState<MapViewState>(INITIAL_VIEW_STATE);
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [, updateSearchParams] = useUpdateSearchParams();
-  const showCapitalProjects = searchParams.get("capitalProjects") !== "off";
-  const showCbbr = searchParams.get("cbbr") !== "off";
-
-  const {
-    boroughs,
-    communityDistricts,
-    cityCouncilDistricts,
-    managingAgencies,
-    agencyBudgets,
-  } = useLoaderData<typeof loader>();
+  const [, setSearchParams] = useSearchParams();
 
   const clearAllFilters = () => {
     setSearchParams({});
@@ -188,175 +87,39 @@ export default function App() {
     });
   };
 
-  const clearCapitalProjectFilters = () => {
-    updateSearchParams({
-      managingAgency: null,
-      agencyBudget: null,
-      commitmentsTotalMin: null,
-      commitmentsTotalMax: null,
-    });
-  };
-
-  const location = useLocation();
-
   return (
     <Document>
       <StreetscapeProvider>
         <ClientOnly>
-          {() =>
-            location.pathname === "/about" ? (
-              <About />
-            ) : (
-              <>
-                <Atlas
-                  viewState={viewState}
-                  setViewState={(MapViewState) => setViewState(MapViewState)}
-                  showCapitalProjects={showCapitalProjects}
-                  showCbbr={showCbbr}
-                />{" "}
-                <Grid
-                  templateColumns={{
-                    base: "0 [col-start] 1fr repeat(6, 1fr) 1fr [col-end] 0",
-                    md: "1.5dvw [col-start] 1fr repeat(10, 1fr) 1fr [col-end] 1.5dvw",
-                    lg: "1.18dvw [col-start] 1fr repeat(10, 1fr) 1fr [col-end] 1.18dvw",
-                    xl: "0.86dvw [col-start] 1fr repeat(10, 1fr) 1fr [col-end] 0.86dvw",
-                    "2xl":
-                      "0.8dvw [col-start] 1fr repeat(10, 1fr) 1fr [col-end] 0.82dvw",
-                  }}
-                  gap={{
-                    base: "0 3dvw",
-                    md: "0 1.6dvw",
-                    lg: "0 1.22dvw",
-                    xl: "0 0.94dw",
-                    "2xl": "0 0.78dw",
-                  }}
-                  templateRows={{
-                    base: "7dvh 2dvh [row-start] 1fr [row-end] 2dvh 7dvh",
-                    md: "7dvh 2dvh [row-start] 1fr [row-end] 2dvh",
-                  }}
-                  height="100vh"
-                  sx={{
-                    scrollbarWidth: "none",
-                  }}
-                >
-                  <HeaderBar clearSelections={clearAllFilters} />
-                  <GridItem
-                    gridColumn={{
-                      base: "col-start / span 7",
-                      md: "col-start / span 4",
-                      xl: "col-start / span 3",
-                      "2xl": "col-start / span 2",
-                    }}
-                    gridRow={{
-                      base: "row-start / row-end",
-                      md: "row-start / row-end",
-                      lg: "row-start / span 1",
-                    }}
-                    height={"100%"}
-                    overflowY={{ lg: "scroll" }}
-                    zIndex={"1"}
-                    sx={{
-                      scrollbarWidth: "none",
-                    }}
-                  >
-                    <Flex
-                      direction={"column"}
-                      width={{ base: "100%", lg: "auto" }}
-                      alignItems={"center"}
-                      flexShrink={{ lg: 0 }}
-                      maxHeight={{
-                        base: "82vh",
-                        lg: "full",
-                      }}
-                      backgroundColor={"white"}
-                      borderRadius={10}
-                      overflowY={"scroll"}
-                      padding={4}
-                      sx={{
-                        scrollbarWidth: "none",
-                      }}
-                      boxShadow={"0 2px 8px 0 rgba(0, 0, 0, 0.20)"}
-                    >
-                      <Accordion
-                        allowMultiple
-                        defaultIndex={[0]}
-                        width={"100%"}
-                      >
-                        <MapLayersPanel>
-                          <Box
-                            display={"flex"}
-                            flexDirection={"column"}
-                            gap={2}
-                          >
-                            <CapitalProjectLayerToggle />
-                            <SearchByAttributeMenu
-                              agencies={managingAgencies}
-                              projectTypes={agencyBudgets}
-                              onClear={clearCapitalProjectFilters}
-                            />
-                            <CommunityBoardBudgetRequestLayerToggle />
-                            <CommunityBoardBudgetRequestLegend />
-                          </Box>
-                        </MapLayersPanel>
-                        <FilterMenu
-                          boroughs={boroughs}
-                          communityDistricts={communityDistricts}
-                          cityCouncilDistricts={cityCouncilDistricts}
-                        />
-                        <HowToUseThisTool />
-                      </Accordion>
-                    </Flex>
-                  </GridItem>
-                  <GridItem
-                    gridColumn={{
-                      base: "1 / -1",
-                      md: "9 / span 5",
-                      xl: "10 / col-end",
-                      "2xl": "11 / col-end",
-                    }}
-                    gridRow={{
-                      base: "3 / -1",
-                      md: "row-start / row-end",
-                      lg: "row-start / span 1",
-                    }}
-                    height={"100%"}
-                    pointerEvents={"none"}
-                    zIndex={"2"}
-                    sx={{
-                      scrollbarWidth: "none",
-                    }}
-                    overflowY={"scroll"}
-                    display={"flex"}
-                    flexDirection={"column"}
-                    justifyContent={{ base: "end", md: "start" }}
-                  >
-                    <Flex
-                      width={"full"}
-                      gap={3}
-                      pointerEvents={"none"}
-                      sx={{
-                        "> *": {
-                          pointerEvents: "auto",
-                        },
-                        scrollbarWidth: "none",
-                      }}
-                      direction={"column"}
-                      flexShrink={{ lg: 0 }}
-                      maxHeight={"full"}
-                      justify={"end"}
-                      backgroundColor={"white"}
-                      borderRadius={10}
-                      overflowY={"scroll"}
-                      padding={4}
-                      boxShadow={"0 8px 4px 0 rgba(0, 0, 0, 0.08)"}
-                    >
-                      <Outlet />
-                    </Flex>
-                  </GridItem>
-                </Grid>
-              </>
-            )
-          }
+          {() => (
+            <Grid
+              templateColumns={{
+                base: "0 [col-start] 1fr repeat(6, 1fr) 1fr [col-end] 0",
+                md: "1.5dvw [col-start] 1fr repeat(10, 1fr) 1fr [col-end] 1.5dvw",
+                lg: "1.18dvw [col-start] 1fr repeat(10, 1fr) 1fr [col-end] 1.18dvw",
+                xl: "0.86dvw [col-start] 1fr repeat(10, 1fr) 1fr [col-end] 0.86dvw",
+                "2xl":
+                  "0.8dvw [col-start] 1fr repeat(10, 1fr) 1fr [col-end] 0.82dvw",
+              }}
+              gap={{
+                base: "0 3dvw",
+                md: "0 1.6dvw",
+                lg: "0 1.22dvw",
+                xl: "0 0.94dw",
+                "2xl": "0 0.78dw",
+              }}
+              templateRows={{
+                base: "7dvh 2dvh [row-start] 1fr [row-end] 2dvh 7dvh",
+                md: "7dvh 2dvh [row-start] 1fr [row-end] 2dvh",
+              }}
+              height="100vh"
+            >
+              <HeaderBar clearSelections={clearAllFilters} />
+              <Outlet
+                context={{ viewState, setViewState } satisfies RootContextType}
+              />
+            </Grid>
+          )}
         </ClientOnly>
       </StreetscapeProvider>
     </Document>

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -6,29 +6,31 @@ import {
 } from "@react-router/dev/routes";
 
 export default [
-  index("routes/home.tsx"),
-  route("about", "routes/about.tsx"),
-  layout("layouts/ResultsPanel.tsx", [
+  layout("layouts/MapPage.tsx", [
+    index("routes/home.tsx"),
+    layout("layouts/ResultsPanel.tsx", [
+      route(
+        "community-board-budget-requests",
+        "routes/community-board-budget-requests.tsx",
+      ),
+      route("capital-projects", "routes/capital-projects.tsx"),
+    ]),
     route(
-      "community-board-budget-requests",
-      "routes/community-board-budget-requests.tsx",
+      "capital-projects/:managingCode/:capitalProjectId",
+      "routes/capital-projects_.$managingCode.$capitalProjectId.tsx",
     ),
-    route("capital-projects", "routes/capital-projects.tsx"),
+    route(
+      "boroughs/:boroughId/community-districts/:communityDistrictId/capital-projects/:managingCode/:capitalProjectId",
+      "routes/boroughs.$boroughId.community-districts.$communityDistrictId.capital-projects_.$managingCode.$capitalProjectId.tsx",
+    ),
+    route(
+      "city-council-districts/:cityCouncilDistrictId/capital-projects/:managingCode/:capitalProjectId",
+      "routes/city-council-districts.$cityCouncilDistrictId.capital-projects_.$managingCode.$capitalProjectId.tsx",
+    ),
+    route(
+      "community-board-budget-requests/:cbbrId",
+      "routes/community-board-budget-requests_.$cbbrId.tsx",
+    ),
   ]),
-  route(
-    "capital-projects/:managingCode/:capitalProjectId",
-    "routes/capital-projects_.$managingCode.$capitalProjectId.tsx",
-  ),
-  route(
-    "boroughs/:boroughId/community-districts/:communityDistrictId/capital-projects/:managingCode/:capitalProjectId",
-    "routes/boroughs.$boroughId.community-districts.$communityDistrictId.capital-projects_.$managingCode.$capitalProjectId.tsx",
-  ),
-  route(
-    "city-council-districts/:cityCouncilDistrictId/capital-projects/:managingCode/:capitalProjectId",
-    "routes/city-council-districts.$cityCouncilDistrictId.capital-projects_.$managingCode.$capitalProjectId.tsx",
-  ),
-  route(
-    "community-board-budget-requests/:cbbrId",
-    "routes/community-board-budget-requests_.$cbbrId.tsx",
-  ),
+  layout("layouts/NonMapPage.tsx", [route("about", "routes/about.tsx")]),
 ] satisfies RouteConfig;

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -7,626 +7,529 @@ import {
   Box,
   ExternalLinkIcon,
   Flex,
-  Grid,
-  GridItem,
   Heading,
   Link,
   Text,
   VStack,
 } from "@nycplanning/streetscape";
-import { HeaderBar } from "~/components/HeaderBar";
 
 export default function About() {
   return (
-    <Grid
-      templateColumns={{
-        base: "0 [col-start] 1fr repeat(6, 1fr) 1fr [col-end] 0",
-        md: "1.5dvw [col-start] 1fr repeat(10, 1fr) 1fr [col-end] 1.5dvw",
-        lg: "1.18dvw [col-start] 1fr repeat(10, 1fr) 1fr [col-end] 1.18dvw",
-        xl: "0.86dvw [col-start] 1fr repeat(10, 1fr) 1fr [col-end] 0.86dvw",
-      }}
-      gap={{
-        base: "0 3dvw",
-        md: "0 1.6dvw",
-        lg: "0 1.22dvw",
-        xl: "0 0.94dw",
-      }}
-      gridAutoRows={{
-        base: "7dvh auto auto auto",
-      }}
+    <Flex
+      direction={"column"}
+      alignItems={"center"}
+      flexShrink={{ lg: 0 }}
       sx={{
         scrollbarWidth: "none",
       }}
     >
-      <HeaderBar />
-      <GridItem
-        gridColumnStart={{
-          base: "2",
-          lg: "3",
-          xl: "4",
-        }}
-        gridColumnEnd={{
-          base: "-2",
-          lg: "10",
-          xl: "9",
-        }}
-        gridRowStart={"2"}
-        gridRowEnd={"3"}
-        pt={8}
+      <Heading
+        as="h1"
+        fontSize={"xl"}
+        pb={9}
+        borderBottom={"1px solid"}
+        borderColor={"gray.200"}
       >
-        <Flex
-          direction={"column"}
-          alignItems={"center"}
-          flexShrink={{ lg: 0 }}
-          sx={{
-            scrollbarWidth: "none",
-          }}
-        >
-          <Heading
-            as="h1"
-            fontSize={"xl"}
-            pb={9}
-            borderBottom={"1px solid"}
-            borderColor={"gray.200"}
-          >
-            The{" "}
-            <Text as="span" fontWeight={"bold"}>
-              Capital Projects Portal (CPP)
-            </Text>{" "}
-            helps New Yorkers explore where and how the City is investing in
-            capital projects and understand community priorities across
-            neighborhoods. CPP brings together information from multiple City
-            sources to{" "}
-            <Text as="span" fontWeight={"bold"}>
-              increase transparency, support planning, and make it easier to
-              explore capital investments and community requests in one place.
-            </Text>
-          </Heading>
-          <Heading
-            as="h1"
-            fontSize={"2xl"}
-            pt={9}
-            pb={4}
-            fontWeight={"bold"}
-            alignSelf={"stretch"}
-          >
-            Capital Projects Data (CPDB)
-          </Heading>
-          <Text pb={6}>
-            The{" "}
-            <Text as="span" fontWeight={"bold"}>
-              Capital Projects Database (CPDB)
-            </Text>{" "}
-            shows major City investments in physical improvements such as parks,
-            schools, roads, and infrastructure. Projects are compiled from the{" "}
-            <Text as="span" fontWeight={"bold"}>
-              Capital Commitment Plan
-            </Text>{" "}
-            and other public sources to give a neighborhood-level view of where
-            capital work is planned or underway.
-          </Text>
-          <Accordion allowMultiple allowToggle width={"100%"}>
-            <AccordionItem borderTop={"unset"}>
-              <AccordionButton paddingInline={0}>
-                <Heading
-                  as="h2"
-                  fontSize="md"
-                  flex="1"
-                  textAlign="left"
-                  fontWeight={"bold"}
-                >
-                  What is a capital project?
-                </Heading>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel>
-                A capital project involves construction, reconstruction, or
-                installation of a public improvement worth{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  $50,000 or more
-                </Text>{" "}
-                and expected to last{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  at least five years
-                </Text>
-                .
-              </AccordionPanel>
-            </AccordionItem>
-            <AccordionItem>
-              <AccordionButton paddingInline={0}>
-                <Heading
-                  as="h2"
-                  fontSize="md"
-                  flex="1"
-                  textAlign="left"
-                  fontWeight={"bold"}
-                >
-                  Where the data comes from:
-                </Heading>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel>
-                Most information comes from the{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  Office of Management and Budget (OMB) Capital Commitment Plan
-                </Text>{" "}
-                and is supplemented by data from{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  Checkbook NYC
-                </Text>
-                , the{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  Department of Design and Construction (DDC)
-                </Text>
-                ,{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  Parks (DPR)
-                </Text>
-                ,{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  Emergency Management (OEM)
-                </Text>
-                , and{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  DCP
-                </Text>
-                .
-              </AccordionPanel>
-            </AccordionItem>
-            <AccordionItem>
-              <AccordionButton paddingInline={0}>
-                <Heading
-                  as="h2"
-                  fontSize="md"
-                  flex="1"
-                  textAlign="left"
-                  fontWeight={"bold"}
-                >
-                  How to use it:
-                </Heading>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel>
-                Use the{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  map
-                </Text>{" "}
-                or{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  table
-                </Text>{" "}
-                to see what projects are happening in a neighborhood, explore by
-                agency, and find where multiple projects may overlap.
-              </AccordionPanel>
-            </AccordionItem>
-            <AccordionItem>
-              <AccordionButton paddingInline={0}>
-                <Heading
-                  as="h2"
-                  fontSize="md"
-                  flex="1"
-                  textAlign="left"
-                  fontWeight={"bold"}
-                >
-                  Example questions you can answer:
-                </Heading>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel>
-                <ul>
-                  <li>
-                    What projects are active in a community or council district?
-                  </li>
-                  <li>Which agencies have work happening in the same area?</li>
-                  <li>
-                    How are capital dollars being invested in growing
-                    neighborhoods?
-                  </li>
-                </ul>
-              </AccordionPanel>
-            </AccordionItem>
-            <AccordionItem>
-              <AccordionButton paddingInline={0}>
-                <Heading
-                  as="h2"
-                  fontSize="md"
-                  flex="1"
-                  textAlign="left"
-                  fontWeight={"bold"}
-                >
-                  Limitations:
-                </Heading>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel>
-                <ul>
-                  <li>
-                    Data reflects what is published in the Capital Commitment
-                    Plan and may not always show current timelines or budgets.
-                  </li>
-                  <li>
-                    Not all projects have geographic locations, and map data is
-                    approximate.
-                  </li>
-                  <li>
-                    This dataset is best used for{" "}
-                    <Text as="span" fontWeight={"bold"}>
-                      planning coordination
-                    </Text>
-                    , not detailed analysis. To review, all Capital Projects in
-                    CPDB, please refer to the tabular version available at{" "}
-                    <Link
-                      href="https://www.nyc.gov/content/planning/pages/resources/datasets/capital-projects-database"
-                      isExternal
-                    >
-                      Department of City Plannings Website{" "}
-                      <ExternalLinkIcon mx="2px" />
-                    </Link>
-                    .
-                  </li>
-                  <li>
-                    Because of these limitations, the{" "}
-                    <Text as="span" fontWeight={"bold"}>
-                      Capital Projects Map
-                    </Text>{" "}
-                    is intended for{" "}
-                    <Text as="span" fontWeight={"bold"}>
-                      planning coordination and general information
-                    </Text>
-                    , not for detailed or quantitative analysis. Project
-                    budgets, timelines, or outcomes may not be fully captured,
-                    and some planned projects may never advance to completion.
-                  </li>
-                </ul>
-              </AccordionPanel>
-            </AccordionItem>
-          </Accordion>
-          <Flex
-            width={"100%"}
-            flexDirection={{
-              base: "column",
-              lg: "row",
-            }}
-            padding={6}
-            my={6}
-            gap={6}
-            justifyContent={{ lg: "space-between" }}
-            backgroundColor={"brand.50"}
-          >
-            <VStack alignItems={"flex-start"}>
-              <Text fontWeight={"bold"}>Version</Text>
-              <Text>FY26 Executive</Text>
-              <Text fontSize={"xs"} textTransform={"uppercase"}>
-                APRIL, 2025
-              </Text>
-            </VStack>
-            <VStack alignItems={"flex-start"}>
-              <Text fontWeight={"bold"}>Data Dictionary</Text>
-              <Link
-                href="https://s-media.nyc.gov/agencies/dcp/assets/files/excel/data-tools/bytes/cpdb_data_dictionary.xlsx"
-                isExternal
-                color={"primary.600"}
-                textDecorationLine={"underline"}
-              >
-                Data Dictionary
-              </Link>
-              <Text fontSize={"xs"} textTransform={"uppercase"}>
-                EXCEL, 103 KB
-              </Text>
-            </VStack>
-            <VStack alignItems={"flex-start"}>
-              <Text fontWeight={"bold"}>Related Links</Text>
-              <Link
-                href="https://data.cityofnewyork.us/City-Government/Capital-Projects-Database-CPDB-Projects/fi59-268w/about_data"
-                isExternal
-                color={"primary.600"}
-                textDecorationLine={"underline"}
-              >
-                OpenData <ExternalLinkIcon mx="2px" />
-              </Link>
-              <Link
-                href="https://www.nyc.gov/content/planning/pages/resources/datasets/capital-projects-database"
-                isExternal
-                color={"primary.600"}
-                textDecorationLine={"underline"}
-              >
-                City Planning <ExternalLinkIcon mx="2px" />
-              </Link>
-            </VStack>
-          </Flex>
-
-          <Heading
-            as="h1"
-            fontSize={"2xl"}
-            pt={9}
-            pb={4}
-            fontWeight={"bold"}
-            borderTop={"1px solid"}
-            borderColor={"gray.200"}
-            alignSelf={"stretch"}
-          >
-            Community Board Budget Requests (CBBR)
-          </Heading>
-          <Text pb={6}>
-            The{" "}
-            <Text as="span" fontWeight={"bold"}>
-              Community Board Budget Requests (CBBR)
-            </Text>{" "}
-            dataset shows priorities submitted annually by each of New York
-            City&apos;s{" "}
-            <Text as="span" fontWeight={"bold"}>
-              59 community boards
-            </Text>
-            . It includes requests for new programs or capital projects and the
-            City&apos;s agency responses.
-          </Text>
-          <Accordion allowMultiple allowToggle width={"100%"}>
-            <AccordionItem borderTop={"unset"}>
-              <AccordionButton paddingInline={0}>
-                <Heading
-                  as="h2"
-                  fontSize="md"
-                  flex="1"
-                  textAlign="left"
-                  fontWeight={"bold"}
-                >
-                  What is a budget request?
-                </Heading>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel>
-                Each year, community boards submit requests to City agencies for
-                funding in the next budget cycle. CPP maps those marked as{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  capital
-                </Text>{" "}
-                and with{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  location details
-                </Text>
-                .
-              </AccordionPanel>
-            </AccordionItem>
-            <AccordionItem>
-              <AccordionButton paddingInline={0}>
-                <Heading
-                  as="h2"
-                  fontSize="md"
-                  flex="1"
-                  textAlign="left"
-                  fontWeight={"bold"}
-                >
-                  Where the data comes from:
-                </Heading>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel>
-                Requests are taken from the{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  Community District Needs Statements
-                </Text>{" "}
-                compiled by community boards and published by DCP in the{" "}
-                <Text as="span" fontWeight={"bold"}>
-                  Community District Needs Summary
-                </Text>
-                .
-              </AccordionPanel>
-            </AccordionItem>
-            <AccordionItem>
-              <AccordionButton paddingInline={0}>
-                <Heading
-                  as="h2"
-                  fontSize="md"
-                  flex="1"
-                  textAlign="left"
-                  fontWeight={"bold"}
-                >
-                  How to use it:
-                </Heading>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel>
-                Explore the table or map to see what each community board is
-                requesting, where those needs are located, and how they align
-                with City capital investments.
-              </AccordionPanel>
-            </AccordionItem>
-            <AccordionItem>
-              <AccordionButton paddingInline={0}>
-                <Heading
-                  as="h2"
-                  fontSize="md"
-                  flex="1"
-                  textAlign="left"
-                  fontWeight={"bold"}
-                >
-                  Example questions you can answer:
-                </Heading>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel>
-                <ul>
-                  <li>
-                    What are the top priorities within each community board?
-                  </li>
-                  <li>
-                    How do requests in different policy areas intersect within a
-                    district?
-                  </li>
-                </ul>
-              </AccordionPanel>
-            </AccordionItem>
-            <AccordionItem>
-              <AccordionButton paddingInline={0}>
-                <Heading
-                  as="h2"
-                  fontSize="md"
-                  flex="1"
-                  textAlign="left"
-                  fontWeight={"bold"}
-                >
-                  Limitations:
-                </Heading>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel>
-                <ul>
-                  <li>
-                    Only capital requests with mappable locations are shown.
-                  </li>
-                  <li>
-                    Requests change annually as boards update their priorities
-                    each fall.
-                  </li>
-                </ul>
-              </AccordionPanel>
-            </AccordionItem>
-          </Accordion>
-          <Flex
-            width={"100%"}
-            flexDirection={{
-              base: "column",
-              lg: "row",
-            }}
-            padding={6}
-            mt={6}
-            mb={9}
-            gap={6}
-            justifyContent={{ lg: "space-between" }}
-            backgroundColor={"brand.50"}
-          >
-            <VStack alignItems={"flex-start"}>
-              <Text fontWeight={"bold"}>Version</Text>
-              <Text>FY26 Preliminary</Text>
-              <Text fontSize={"xs"} textTransform={"uppercase"}>
-                JAN, 2025
-              </Text>
-            </VStack>
-            <VStack alignItems={"flex-start"}>
-              <Text fontWeight={"bold"}>Data Dictionary</Text>
-              <Link
-                href="https://s-media.nyc.gov/agencies/dcp/assets/files/excel/data-tools/bytes/cpdb_data_dictionary.xlsx"
-                isExternal
-                color={"primary.600"}
-                textDecorationLine={"underline"}
-              >
-                CBBR Data Dictionary
-              </Link>
-              <Text fontSize={"xs"} textTransform={"uppercase"}>
-                EXCEL, 000 KB
-              </Text>
-            </VStack>
-            <VStack alignItems={"flex-start"}>
-              <Text fontWeight={"bold"}>Related Links</Text>
-              <Link
-                href="https://data.cityofnewyork.us/City-Government/Register-of-Community-Board-Budget-Requests/vn4m-mk4t/about_data"
-                isExternal
-                color={"primary.600"}
-                textDecorationLine={"underline"}
-              >
-                OpenData <ExternalLinkIcon mx="2px" />
-              </Link>
-              <Link
-                href="https://communityprofiles.planning.nyc.gov/"
-                isExternal
-                color={"primary.600"}
-                textDecorationLine={"underline"}
-              >
-                Community Profiles <ExternalLinkIcon mx="2px" />
-              </Link>
-            </VStack>
-          </Flex>
-          <Box
-            mb={9}
-            borderBottom={"1px solid"}
-            borderColor={"gray.200"}
-            width={"100%"}
-          ></Box>
-          <VStack
-            p={6}
-            alignSelf={"stretch"}
-            backgroundColor={"gray.50"}
-            gap={3}
-          >
-            <Text
-              fontSize={"lg"}
-              color={"gray.700"}
-              alignSelf={"stretch"}
+        The{" "}
+        <Text as="span" fontWeight={"bold"}>
+          Capital Projects Portal (CPP)
+        </Text>{" "}
+        helps New Yorkers explore where and how the City is investing in capital
+        projects and understand community priorities across neighborhoods. CPP
+        brings together information from multiple City sources to{" "}
+        <Text as="span" fontWeight={"bold"}>
+          increase transparency, support planning, and make it easier to explore
+          capital investments and community requests in one place.
+        </Text>
+      </Heading>
+      <Heading
+        as="h1"
+        fontSize={"2xl"}
+        pt={9}
+        pb={4}
+        fontWeight={"bold"}
+        alignSelf={"stretch"}
+      >
+        Capital Projects Data (CPDB)
+      </Heading>
+      <Text pb={6}>
+        The{" "}
+        <Text as="span" fontWeight={"bold"}>
+          Capital Projects Database (CPDB)
+        </Text>{" "}
+        shows major City investments in physical improvements such as parks,
+        schools, roads, and infrastructure. Projects are compiled from the{" "}
+        <Text as="span" fontWeight={"bold"}>
+          Capital Commitment Plan
+        </Text>{" "}
+        and other public sources to give a neighborhood-level view of where
+        capital work is planned or underway.
+      </Text>
+      <Accordion allowMultiple allowToggle width={"100%"}>
+        <AccordionItem borderTop={"unset"}>
+          <AccordionButton paddingInline={0}>
+            <Heading
+              as="h2"
+              fontSize="md"
+              flex="1"
+              textAlign="left"
               fontWeight={"bold"}
             >
-              Acknowledgements
+              What is a capital project?
+            </Heading>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel>
+            A capital project involves construction, reconstruction, or
+            installation of a public improvement worth{" "}
+            <Text as="span" fontWeight={"bold"}>
+              $50,000 or more
+            </Text>{" "}
+            and expected to last{" "}
+            <Text as="span" fontWeight={"bold"}>
+              at least five years
             </Text>
-            <Text>
-              The{" "}
-              <Text as="span" fontWeight={"bold"}>
-                Capital Planning and Support (CAPS)
-              </Text>{" "}
-              team thanks our partners across{" "}
-              <Text as="span" fontWeight={"bold"}>
-                Data Engineering
-              </Text>
-              ,{" "}
-              <Text as="span" fontWeight={"bold"}>
-                {" "}
-                Design & Product
-              </Text>
-              , and{" "}
-              <Text as="span" fontWeight={"bold"}>
-                ITD
-              </Text>{" "}
-              for their collaboration. We are also grateful to the many users
-              who have provided feedback—your insights continue to shape
-              CPP&apos;s future enhancements and user experience.
+            .
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionButton paddingInline={0}>
+            <Heading
+              as="h2"
+              fontSize="md"
+              flex="1"
+              textAlign="left"
+              fontWeight={"bold"}
+            >
+              Where the data comes from:
+            </Heading>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel>
+            Most information comes from the{" "}
+            <Text as="span" fontWeight={"bold"}>
+              Office of Management and Budget (OMB) Capital Commitment Plan
+            </Text>{" "}
+            and is supplemented by data from{" "}
+            <Text as="span" fontWeight={"bold"}>
+              Checkbook NYC
             </Text>
-            Community Board Budget Requests (CBBR)
-          </VStack>
-        </Flex>
-      </GridItem>
-      <GridItem
-        gridColumnStart={{
-          base: "2",
-          lg: "10",
-          xl: "9",
+            , the{" "}
+            <Text as="span" fontWeight={"bold"}>
+              Department of Design and Construction (DDC)
+            </Text>
+            ,{" "}
+            <Text as="span" fontWeight={"bold"}>
+              Parks (DPR)
+            </Text>
+            ,{" "}
+            <Text as="span" fontWeight={"bold"}>
+              Emergency Management (OEM)
+            </Text>
+            , and{" "}
+            <Text as="span" fontWeight={"bold"}>
+              DCP
+            </Text>
+            .
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionButton paddingInline={0}>
+            <Heading
+              as="h2"
+              fontSize="md"
+              flex="1"
+              textAlign="left"
+              fontWeight={"bold"}
+            >
+              How to use it:
+            </Heading>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel>
+            Use the{" "}
+            <Text as="span" fontWeight={"bold"}>
+              map
+            </Text>{" "}
+            or{" "}
+            <Text as="span" fontWeight={"bold"}>
+              table
+            </Text>{" "}
+            to see what projects are happening in a neighborhood, explore by
+            agency, and find where multiple projects may overlap.
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionButton paddingInline={0}>
+            <Heading
+              as="h2"
+              fontSize="md"
+              flex="1"
+              textAlign="left"
+              fontWeight={"bold"}
+            >
+              Example questions you can answer:
+            </Heading>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel>
+            <ul>
+              <li>
+                What projects are active in a community or council district?
+              </li>
+              <li>Which agencies have work happening in the same area?</li>
+              <li>
+                How are capital dollars being invested in growing neighborhoods?
+              </li>
+            </ul>
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionButton paddingInline={0}>
+            <Heading
+              as="h2"
+              fontSize="md"
+              flex="1"
+              textAlign="left"
+              fontWeight={"bold"}
+            >
+              Limitations:
+            </Heading>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel>
+            <ul>
+              <li>
+                Data reflects what is published in the Capital Commitment Plan
+                and may not always show current timelines or budgets.
+              </li>
+              <li>
+                Not all projects have geographic locations, and map data is
+                approximate.
+              </li>
+              <li>
+                This dataset is best used for{" "}
+                <Text as="span" fontWeight={"bold"}>
+                  planning coordination
+                </Text>
+                , not detailed analysis. To review, all Capital Projects in
+                CPDB, please refer to the tabular version available at{" "}
+                <Link
+                  href="https://www.nyc.gov/content/planning/pages/resources/datasets/capital-projects-database"
+                  isExternal
+                >
+                  Department of City Plannings Website{" "}
+                  <ExternalLinkIcon mx="2px" />
+                </Link>
+                .
+              </li>
+              <li>
+                Because of these limitations, the{" "}
+                <Text as="span" fontWeight={"bold"}>
+                  Capital Projects Map
+                </Text>{" "}
+                is intended for{" "}
+                <Text as="span" fontWeight={"bold"}>
+                  planning coordination and general information
+                </Text>
+                , not for detailed or quantitative analysis. Project budgets,
+                timelines, or outcomes may not be fully captured, and some
+                planned projects may never advance to completion.
+              </li>
+            </ul>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+      <Flex
+        width={"100%"}
+        flexDirection={{
+          base: "column",
+          lg: "row",
         }}
-        gridColumnEnd={{
-          base: "-2",
-          lg: "12",
-          xl: "12",
-        }}
-        gridRowStart={{
-          base: "3",
-          lg: "2",
-        }}
-        gridRowEnd={{
-          base: "4",
-          lg: "3",
-        }}
-        pt={8}
+        padding={6}
+        my={6}
+        gap={6}
+        justifyContent={{ lg: "space-between" }}
+        backgroundColor={"brand.50"}
       >
-        <VStack
-          alignItems={"flex-start"}
-          py={{
-            base: 9,
-            lg: 0,
-          }}
-        >
-          <Text color={"gray.700"} fontWeight={"bold"}>
-            Feedback
+        <VStack alignItems={"flex-start"}>
+          <Text fontWeight={"bold"}>Version</Text>
+          <Text>FY26 Executive</Text>
+          <Text fontSize={"xs"} textTransform={"uppercase"}>
+            APRIL, 2025
           </Text>
-          <Text>
-            This tool is in active development and DCP is open to any and all
-            feedback. For questions, inquires or feedback on CPP or its content,
-            please send us an email.
-          </Text>
+        </VStack>
+        <VStack alignItems={"flex-start"}>
+          <Text fontWeight={"bold"}>Data Dictionary</Text>
           <Link
-            href="mailto:CAPS@planning.nyc.gov"
+            href="https://s-media.nyc.gov/agencies/dcp/assets/files/excel/data-tools/bytes/cpdb_data_dictionary.xlsx"
+            isExternal
             color={"primary.600"}
             textDecorationLine={"underline"}
           >
-            Email CAPS@planning.nyc.gov
+            Data Dictionary
+          </Link>
+          <Text fontSize={"xs"} textTransform={"uppercase"}>
+            EXCEL, 103 KB
+          </Text>
+        </VStack>
+        <VStack alignItems={"flex-start"}>
+          <Text fontWeight={"bold"}>Related Links</Text>
+          <Link
+            href="https://data.cityofnewyork.us/City-Government/Capital-Projects-Database-CPDB-Projects/fi59-268w/about_data"
+            isExternal
+            color={"primary.600"}
+            textDecorationLine={"underline"}
+          >
+            OpenData <ExternalLinkIcon mx="2px" />
+          </Link>
+          <Link
+            href="https://www.nyc.gov/content/planning/pages/resources/datasets/capital-projects-database"
+            isExternal
+            color={"primary.600"}
+            textDecorationLine={"underline"}
+          >
+            City Planning <ExternalLinkIcon mx="2px" />
           </Link>
         </VStack>
-      </GridItem>
-    </Grid>
+      </Flex>
+
+      <Heading
+        as="h1"
+        fontSize={"2xl"}
+        pt={9}
+        pb={4}
+        fontWeight={"bold"}
+        borderTop={"1px solid"}
+        borderColor={"gray.200"}
+        alignSelf={"stretch"}
+      >
+        Community Board Budget Requests (CBBR)
+      </Heading>
+      <Text pb={6}>
+        The{" "}
+        <Text as="span" fontWeight={"bold"}>
+          Community Board Budget Requests (CBBR)
+        </Text>{" "}
+        dataset shows priorities submitted annually by each of New York
+        City&apos;s{" "}
+        <Text as="span" fontWeight={"bold"}>
+          59 community boards
+        </Text>
+        . It includes requests for new programs or capital projects and the
+        City&apos;s agency responses.
+      </Text>
+      <Accordion allowMultiple allowToggle width={"100%"}>
+        <AccordionItem borderTop={"unset"}>
+          <AccordionButton paddingInline={0}>
+            <Heading
+              as="h2"
+              fontSize="md"
+              flex="1"
+              textAlign="left"
+              fontWeight={"bold"}
+            >
+              What is a budget request?
+            </Heading>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel>
+            Each year, community boards submit requests to City agencies for
+            funding in the next budget cycle. CPP maps those marked as{" "}
+            <Text as="span" fontWeight={"bold"}>
+              capital
+            </Text>{" "}
+            and with{" "}
+            <Text as="span" fontWeight={"bold"}>
+              location details
+            </Text>
+            .
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionButton paddingInline={0}>
+            <Heading
+              as="h2"
+              fontSize="md"
+              flex="1"
+              textAlign="left"
+              fontWeight={"bold"}
+            >
+              Where the data comes from:
+            </Heading>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel>
+            Requests are taken from the{" "}
+            <Text as="span" fontWeight={"bold"}>
+              Community District Needs Statements
+            </Text>{" "}
+            compiled by community boards and published by DCP in the{" "}
+            <Text as="span" fontWeight={"bold"}>
+              Community District Needs Summary
+            </Text>
+            .
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionButton paddingInline={0}>
+            <Heading
+              as="h2"
+              fontSize="md"
+              flex="1"
+              textAlign="left"
+              fontWeight={"bold"}
+            >
+              How to use it:
+            </Heading>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel>
+            Explore the table or map to see what each community board is
+            requesting, where those needs are located, and how they align with
+            City capital investments.
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionButton paddingInline={0}>
+            <Heading
+              as="h2"
+              fontSize="md"
+              flex="1"
+              textAlign="left"
+              fontWeight={"bold"}
+            >
+              Example questions you can answer:
+            </Heading>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel>
+            <ul>
+              <li>What are the top priorities within each community board?</li>
+              <li>
+                How do requests in different policy areas intersect within a
+                district?
+              </li>
+            </ul>
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionButton paddingInline={0}>
+            <Heading
+              as="h2"
+              fontSize="md"
+              flex="1"
+              textAlign="left"
+              fontWeight={"bold"}
+            >
+              Limitations:
+            </Heading>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel>
+            <ul>
+              <li>Only capital requests with mappable locations are shown.</li>
+              <li>
+                Requests change annually as boards update their priorities each
+                fall.
+              </li>
+            </ul>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+      <Flex
+        width={"100%"}
+        flexDirection={{
+          base: "column",
+          lg: "row",
+        }}
+        padding={6}
+        mt={6}
+        mb={9}
+        gap={6}
+        justifyContent={{ lg: "space-between" }}
+        backgroundColor={"brand.50"}
+      >
+        <VStack alignItems={"flex-start"}>
+          <Text fontWeight={"bold"}>Version</Text>
+          <Text>FY26 Preliminary</Text>
+          <Text fontSize={"xs"} textTransform={"uppercase"}>
+            JAN, 2025
+          </Text>
+        </VStack>
+        <VStack alignItems={"flex-start"}>
+          <Text fontWeight={"bold"}>Data Dictionary</Text>
+          <Link
+            href="https://s-media.nyc.gov/agencies/dcp/assets/files/excel/data-tools/bytes/cpdb_data_dictionary.xlsx"
+            isExternal
+            color={"primary.600"}
+            textDecorationLine={"underline"}
+          >
+            CBBR Data Dictionary
+          </Link>
+          <Text fontSize={"xs"} textTransform={"uppercase"}>
+            EXCEL, 000 KB
+          </Text>
+        </VStack>
+        <VStack alignItems={"flex-start"}>
+          <Text fontWeight={"bold"}>Related Links</Text>
+          <Link
+            href="https://data.cityofnewyork.us/City-Government/Register-of-Community-Board-Budget-Requests/vn4m-mk4t/about_data"
+            isExternal
+            color={"primary.600"}
+            textDecorationLine={"underline"}
+          >
+            OpenData <ExternalLinkIcon mx="2px" />
+          </Link>
+          <Link
+            href="https://communityprofiles.planning.nyc.gov/"
+            isExternal
+            color={"primary.600"}
+            textDecorationLine={"underline"}
+          >
+            Community Profiles <ExternalLinkIcon mx="2px" />
+          </Link>
+        </VStack>
+      </Flex>
+      <Box
+        mb={9}
+        borderBottom={"1px solid"}
+        borderColor={"gray.200"}
+        width={"100%"}
+      ></Box>
+      <VStack p={6} alignSelf={"stretch"} backgroundColor={"gray.50"} gap={3}>
+        <Text
+          fontSize={"lg"}
+          color={"gray.700"}
+          alignSelf={"stretch"}
+          fontWeight={"bold"}
+        >
+          Acknowledgements
+        </Text>
+        <Text>
+          The{" "}
+          <Text as="span" fontWeight={"bold"}>
+            Capital Planning and Support (CAPS)
+          </Text>{" "}
+          team thanks our partners across{" "}
+          <Text as="span" fontWeight={"bold"}>
+            Data Engineering
+          </Text>
+          ,{" "}
+          <Text as="span" fontWeight={"bold"}>
+            {" "}
+            Design & Product
+          </Text>
+          , and{" "}
+          <Text as="span" fontWeight={"bold"}>
+            ITD
+          </Text>{" "}
+          for their collaboration. We are also grateful to the many users who
+          have provided feedback—your insights continue to shape CPP&apos;s
+          future enhancements and user experience.
+        </Text>
+        Community Board Budget Requests (CBBR)
+      </VStack>
+    </Flex>
   );
 }


### PR DESCRIPTION
This Issue covers some refactoring to be done as a follow up to #238 and #226. Now that `routes.ts` has been updated to the new React Router syntax, we should refactor the app to properly nest shared UI components and routes to keep it DRY and using the same CSS grid across all pages.

### Acceptance Criteria
* Refactor `root.tsx` to only include the component used across _all_ routes. This is likely only `<HeaderBar>` and the top level `<Grid>`
* Add a new [layout route](https://reactrouter.com/start/framework/routing#layout-routes) to be used by all routes that render on the map that contains all UI shared by those routes. This layout should render `<Outlet>` in the slot where nested routes should appear
* Update the use of `<Atlas>` to render inside the grid as appropriate. 
* Update `routes.ts` to use this new layout and render routes as necessary
* Remove code no longer necessary in `about.ts`, such as `<Grid>`, and update it to use the same shared grid.

Closes #247 