### PR TITLE
Add logic to fix trackpad zooming bug 

### DIFF
--- a/app/extensions/FlyToGeoJsonExtension.ts
+++ b/app/extensions/FlyToGeoJsonExtension.ts
@@ -46,7 +46,11 @@ export class FlyToGeoJsonExtension extends LayerExtension {
       deckInstance.props.onViewStateChange({
         viewState: newViewState,
         viewId: viewport.id,
-        interactionState: {},
+        interactionState: {
+          isZooming: true,
+          isPanning: true,
+          inTransition: true,
+        },
       });
     }
   }


### PR DESCRIPTION
Resolves #137. This change is meant to fix the jumpy zooming issues we've been seeing when using trackpads and is based on this [comment](https://github.com/visgl/deck.gl/issues/7158#issuecomment-2305388963) in a Deck issue. I tested the following on Firefox, Chrome, and Safari:
* Zooming with trackpad
* Zooming with mouse wheel
* "flyto" by clicking on a project
* "flyto" by clicking on the logo to reset the view state to defaults.