### PR TITLE
276 [Bug]: Can't move map on mobile (iPhone safari)

### DIFF
--- a/app/layouts/MapPage.tsx
+++ b/app/layouts/MapPage.tsx
@@ -150,7 +150,7 @@ export default function MapPage() {
           md: "row-start / row-end",
           lg: "row-start / span 1",
         }}
-        height={"100%"}
+        height={"fit-content"}
         overflowY={{ lg: "scroll" }}
         zIndex={"1"}
         sx={{


### PR DESCRIPTION
Issue was actually on all screen sizes and browsers.  The left panel was the full height of the page, preventing the map beneath it from being clicked.

Closes #276 