### PR TITLE
265 [Bug]: Server crashes when minimum or maximum is 4.x M or B (e.g. 4.1m)

### DIFF
--- a/app/components/ProjectAmountMenu/index.tsx
+++ b/app/components/ProjectAmountMenu/index.tsx
@@ -73,7 +73,7 @@ export function ProjectAmountMenu({
               ? (
                   parseFloat(commitmentsTotalMinInputValue) *
                   getMultiplier(commitmentsTotalMinSelectValue)
-                ).toString()
+                ).toFixed(2)
               : null,
           commitmentsTotalMax:
             commitmentsTotalMaxInputValue !== "" &&
@@ -81,7 +81,7 @@ export function ProjectAmountMenu({
               ? (
                   parseFloat(commitmentsTotalMaxInputValue) *
                   getMultiplier(commitmentsTotalMaxSelectValue)
-                ).toString()
+                ).toFixed(2)
               : null,
         });
       }


### PR DESCRIPTION
The issue was caused by Javascript's handling of floats, which was causing rounding issues.  For example, entering 4.1M set the value to "4099999.9999999995".  This was corrected by rounding the number to 2 decimal places.

Closes #265