### PR TITLE
276 [Bug]: Can't move map on mobile (iPhone safari)

### DIFF
--- a/app/layouts/MapPage.tsx
+++ b/app/layouts/MapPage.tsx
@@ -150,7 +150,8 @@ export default function MapPage() {
           md: "row-start / row-end",
           lg: "row-start / span 1",
         }}
-        height={"100%"}
+        height={"fit-content"}
+        maxHeight={"100%"}
         overflowY={{ lg: "scroll" }}
         zIndex={"1"}
         sx={{
@@ -164,6 +165,7 @@ export default function MapPage() {
           flexShrink={{ lg: 0 }}
           maxHeight={{
             base: "82vh",
+            md: "89vh",
             lg: "full",
           }}
           backgroundColor={"white"}


### PR DESCRIPTION
Issue was actually on all screen sizes and browsers.  The left panel was the full height of the page, preventing the map beneath it from being clicked.

Closes #276 