### PR TITLE
292 [Bug]: URLs causing horizontal overflow on CBBR page

### DIFF
--- a/app/components/CommunityBoardBudgetRequestDetail/index.tsx
+++ b/app/components/CommunityBoardBudgetRequestDetail/index.tsx
@@ -89,13 +89,13 @@ export function CommunityBoardBudgetRequestDetail({
         <Text fontWeight={"bold"} fontSize={"sm"}>
           Request from {cbbr.communityBoardId}:
         </Text>
-        <Text>{cbbr.description}</Text>
+        <Text overflowWrap={"anywhere"}>{cbbr.description}</Text>
       </VStack>
       <VStack alignItems={"flex-start"} gap={0}>
         <Text fontWeight={"bold"} fontSize={"sm"}>
           Response from {agencyName}:
         </Text>
-        <Text>
+        <Text overflowWrap={"anywhere"}>
           {agencyCategoryResponse}. {cbbr.cbbrAgencyResponse}
         </Text>
       </VStack>


### PR DESCRIPTION
This adds `overflow-wrap: anywhere` to the text so that URLs will wrap mid-string and not cause the box to overflow.

Closes #292