### PR TITLE
294 [Bug]: CBBR strings contain newline characters which render incorrectly

### DIFF
--- a/app/components/CommunityBoardBudgetRequestDetail/index.tsx
+++ b/app/components/CommunityBoardBudgetRequestDetail/index.tsx
@@ -27,6 +27,11 @@ export function CommunityBoardBudgetRequestDetail({
   agencyCategoryResponse,
   onNavigationClick,
 }: CommunityBoardBudgetRequestDetailProps) {
+  const agencyCategoryResponseAndResponse: Array<string> =
+    `${agencyCategoryResponse}. ${cbbr.cbbrAgencyResponse}`
+      .split("\\n")
+      .filter((line: string) => line !== "");
+
   return (
     <VStack
       alignItems={"flex-start"}
@@ -100,9 +105,17 @@ export function CommunityBoardBudgetRequestDetail({
         <Text fontWeight={"bold"} fontSize={"sm"}>
           Response from {agencyName}:
         </Text>
-        <Text>
-          {agencyCategoryResponse}. {cbbr.cbbrAgencyResponse}
-        </Text>
+        {agencyCategoryResponseAndResponse.map(
+          (line: string, index: number) => (
+            <Text
+              key={`cbbrAgencyResponse${index}`}
+              overflowWrap={"anywhere"}
+              mb={2}
+            >
+              {line}
+            </Text>
+          ),
+        )}
       </VStack>
       {cbbr.isContinuedSupport && (
         <Text


### PR DESCRIPTION
The agency responses contain `\n` and `\n\n`.  This:

1. Concatenates the agency response type, a period, and the agency response (so that it does not create a new line)
2. Splits the string into an array by `\n`
3. Filters out empty strings created by `\n\n`
4. Loops through the array, creating a `<Text>` with each item

The result is that the responses display with newlines as the agencies intended. 

Closes #294 
