### PR TITLE
Fix url on click of budget request on map

### DIFF
--- a/app/components/layers/useCommunityBoardBudgetRequestsLayer.client.tsx
+++ b/app/components/layers/useCommunityBoardBudgetRequestsLayer.client.tsx
@@ -167,7 +167,7 @@ export function useCommunityBoardBudgetRequestsLayer(opts?: {
       if (indvidualCbbrId === `${cbbrId}`) return;
       const cbbrRouteSuffix = `/community-board-budget-requests/${indvidualCbbrId}`;
       navigate({
-        pathname: `${endpointPrefix}${cbbrRouteSuffix}`,
+        pathname: `${cbbrRouteSuffix}`,
         search: `?${searchParams.toString()}`,
       });
     },


### PR DESCRIPTION
Remove endpoint prefix from community board budget request path

closes #298