### PR TITLE
376 New location filtering UI for Community Boards and City Council Districts

### DIFF
--- a/app/components/AdminDropdownContent/HowToUseThisTool.tsx
+++ b/app/components/AdminDropdownContent/HowToUseThisTool.tsx
@@ -10,7 +10,7 @@ import { env } from "~/utils/env";
 
 export function HowToUseThisTool() {
   return (
-    <AccordionItem borderBottom={ env.facDbPhase1 == "ON" ? "none" : ""}>
+    <AccordionItem borderBottom={env.facDbPhase1 == "ON" ? "none" : ""}>
       <AccordionButton aria-label="Toggle how to use this tool panel" p={0}>
         <Heading
           flex="1"

--- a/app/components/FilterMenu.tsx
+++ b/app/components/FilterMenu.tsx
@@ -47,7 +47,7 @@ export const FilterMenu = ({
   };
 
   return (
-    <AccordionItem borderBottom={ env.facDbPhase1 == "ON" ? "none" : ""}>
+    <AccordionItem borderBottom={env.facDbPhase1 == "ON" ? "none" : ""}>
       <AccordionButton aria-label="Close geography filter menu" p={0}>
         <Heading
           flex="1"

--- a/app/components/atlas.client.tsx
+++ b/app/components/atlas.client.tsx
@@ -5,12 +5,15 @@ import "@deck.gl/widgets/stylesheet.css";
 import {
   useCapitalProjectsLayer,
   useCommunityDistrictsLayer,
+  useCommunityDistrictsOutlinesLayer,
   useCityCouncilDistrictsLayer,
+  useCityCouncilDistrictsOutlinesLayer,
   useCommunityDistrictLayer,
   useCommunityBoardBudgetRequestsLayer,
   useCityCouncilDistrictLayer,
   useCapitalProjectBudgetedGeoJsonLayer,
   useCommunityBoardBudgetRequestsGeoJsonLayer,
+  useBoundaryMVTMask,
 } from "./layers";
 import type { MapView, MapViewState } from "@deck.gl/core";
 import { FlyToInterpolator } from "@deck.gl/core";
@@ -18,7 +21,7 @@ import { env } from "~/utils/env";
 
 export const MAX_ZOOM = 20;
 export const MIN_ZOOM = 10;
-const { basemapUrl } = env;
+const { basemapUrl, facDbPhase1 } = env;
 
 export const INITIAL_VIEW_STATE = {
   longitude: -74.0008,
@@ -77,10 +80,41 @@ export function Atlas({
     useCommunityBoardBudgetRequestsGeoJsonLayer();
   const communityDistrictsLayer = useCommunityDistrictsLayer();
   const communityDistrictLayer = useCommunityDistrictLayer();
+  const communityDistrictsOutlinesLayer = useCommunityDistrictsOutlinesLayer();
 
   const cityCouncilDistrictsLayer = useCityCouncilDistrictsLayer();
-
   const cityCouncilDistrictLayer = useCityCouncilDistrictLayer();
+  const cityCouncilDistrictsOutlinesLayer =
+    useCityCouncilDistrictsOutlinesLayer();
+
+  const boundaryMvtMask = useBoundaryMVTMask();
+
+  const LAYER_LIST =
+    facDbPhase1 == "ON"
+      ? [
+          boundaryMvtMask,
+          communityDistrictsOutlinesLayer,
+          cityCouncilDistrictsOutlinesLayer,
+          communityDistrictsLayer,
+          communityDistrictLayer,
+          cityCouncilDistrictsLayer,
+          cityCouncilDistrictLayer,
+          capitalProjectsLayer,
+          capitalProjectBudgetedGeoJsonLayer,
+          communityBoardBudgetRequestsLayer,
+          communityBoardBudgetRequestGeoJsonLayer,
+        ]
+      : [
+          capitalProjectsLayer,
+          capitalProjectBudgetedGeoJsonLayer,
+          communityDistrictsLayer,
+          communityDistrictLayer,
+          communityBoardBudgetRequestsLayer,
+          communityBoardBudgetRequestGeoJsonLayer,
+          cityCouncilDistrictsLayer,
+          cityCouncilDistrictLayer,
+        ];
+
   return (
     <DeckGL<MapView>
       viewState={viewState}
@@ -135,16 +169,7 @@ export function Atlas({
       style={{
         position: "relative",
       }}
-      layers={[
-        capitalProjectsLayer,
-        capitalProjectBudgetedGeoJsonLayer,
-        communityDistrictsLayer,
-        communityDistrictLayer,
-        communityBoardBudgetRequestsLayer,
-        communityBoardBudgetRequestGeoJsonLayer,
-        cityCouncilDistrictsLayer,
-        cityCouncilDistrictLayer,
-      ]}
+      layers={LAYER_LIST}
       getCursor={({ isDragging, isHovering }) => {
         if (isDragging) {
           return "grabbing";

--- a/app/components/layers/index.tsx
+++ b/app/components/layers/index.tsx
@@ -1,9 +1,12 @@
 export { useCapitalProjectsLayer } from "./useCapitalProjectsLayer.client";
 export { useCommunityDistrictsLayer } from "./useCommunityDistrictsLayer.client";
+export { useCommunityDistrictsOutlinesLayer } from "./useCommunityDistrictsOutlinesLayer.client";
 export { useCommunityDistrictLayer } from "./useCommunityDistrictLayer.client";
 export { useCityCouncilDistrictsLayer } from "./useCityCouncilDistrictsLayer.client";
+export { useCityCouncilDistrictsOutlinesLayer } from "./useCityCouncilDistrictsOutlinesLayer.client";
 export { useCityCouncilDistrictLayer } from "./useCityCouncilDistrictLayer.client";
 export { useCapitalProjectBudgetedGeoJsonLayer } from "./useCapitalProjectBudgetedGeoJsonLayer.client";
 export { useCommunityBoardBudgetRequestsLayer } from "./useCommunityBoardBudgetRequestsLayer.client";
 export { useCommunityBoardBudgetRequestsGeoJsonLayer } from "./useCommunityBoardBudgetRequestsGeoJsonLayer.client";
+export { useBoundaryMVTMask } from "./useBoundaryMVTMask.client";
 export { IconClusterLayer } from "./icon-cluster-layer";

--- a/app/components/layers/useBoundaryMVTMask.client.tsx
+++ b/app/components/layers/useBoundaryMVTMask.client.tsx
@@ -1,0 +1,59 @@
+import {
+  DataFilterExtension,
+  DataFilterExtensionProps,
+} from "@deck.gl/extensions";
+import { MVTLayer } from "@deck.gl/geo-layers";
+import { env } from "~/utils/env";
+import { useSearchParams } from "react-router";
+import { BoroughId, DistrictId, DistrictType } from "../../utils/types";
+import { CommunityDistrictProperties } from "./useCommunityDistrictsLayer.client";
+
+const { zoningApiUrl } = env;
+
+export function useBoundaryMVTMask() {
+  const [searchParams] = useSearchParams();
+  const districtType = searchParams.get("districtType") as DistrictType;
+  const boroughId = searchParams.get("boroughId") as BoroughId;
+  const districtId = searchParams.get("districtId") as DistrictId;
+
+  switch (districtType) {
+    case "cd":
+      return new MVTLayer<unknown, DataFilterExtensionProps>({
+        id: "boundary-mvt",
+        data: [`${zoningApiUrl}/api/community-districts/{z}/{x}/{y}.pbf`],
+        // https://github.com/visgl/deck.gl/issues/8919#issuecomment-2134505299
+        binary: false,
+        getFilterCategory: ({
+          properties,
+        }: {
+          properties: CommunityDistrictProperties;
+        }) => {
+          return properties.boroughIdCommunityDistrictId;
+        },
+        filterCategories: [
+          boroughId && districtId ? `${boroughId}${districtId}` : "",
+        ],
+        extensions: [
+          new DataFilterExtension({
+            categorySize: 1,
+          }),
+        ],
+        operation: "mask",
+      });
+    default:
+      return new MVTLayer<unknown, DataFilterExtensionProps>({
+        id: "boundary-mvt",
+        data: [`${zoningApiUrl}/api/city-council-districts/{z}/{x}/{y}.pbf`],
+        // https://github.com/visgl/deck.gl/issues/8919#issuecomment-2134505299
+        binary: false,
+        getFilterCategory: ({ properties }) => properties.id,
+        filterCategories: [districtId ? districtId : ""],
+        extensions: [
+          new DataFilterExtension({
+            categorySize: 1,
+          }),
+        ],
+        operation: "mask",
+      });
+  }
+}

--- a/app/components/layers/useCapitalProjectsLayer.client.tsx
+++ b/app/components/layers/useCapitalProjectsLayer.client.tsx
@@ -8,6 +8,8 @@ import {
 import {
   DataFilterExtension,
   DataFilterExtensionProps,
+  MaskExtension,
+  MaskExtensionProps,
 } from "@deck.gl/extensions";
 import type { Feature, Geometry } from "geojson";
 import {
@@ -20,7 +22,7 @@ import {
 import { env } from "~/utils/env";
 import { loader as mapPageLoader } from "~/layouts/MapPage";
 
-const { zoningApiUrl } = env;
+const { zoningApiUrl, facDbPhase1 } = env;
 export interface CapitalProjectProperties {
   managingCodeCapitalProjectId: string;
   managingAgency: string;
@@ -74,6 +76,93 @@ export function useCapitalProjectsLayer(opts: {
   const fullAgencyAcronymList = loaderData.managingAgencies
     ? loaderData.managingAgencies.map((agency) => agency.initials)
     : [];
+
+  if (facDbPhase1 == "ON")
+    return new MVTLayer<
+      CapitalProjectProperties,
+      DataFilterExtensionProps<Feature<Geometry, CapitalProjectProperties>> &
+        MaskExtensionProps
+    >({
+      id: "capitalProjects",
+      data: [`${zoningApiUrl}/api/capital-projects/{z}/{x}/{y}.pbf`],
+      uniqueIdProperty: "managingCodeCapitalProjectId",
+      autoHighlight: true,
+      visible,
+      highlightColor: [129, 230, 217, 218],
+      highlightedFeatureId: hoveredCapitalProject,
+      pickable: true,
+      getFilterValue: (f: Feature<Geometry, CapitalProjectProperties>) =>
+        f.properties.commitmentsTotal,
+      filterRange: [min, max],
+      getFilterCategory: (f: Feature<Geometry, CapitalProjectProperties>) => {
+        const agencyBudgets = JSON.parse(f.properties.agencyBudgets);
+        return [
+          f.properties.managingAgency,
+          agencyBudget === null || agencyBudgets.includes(agencyBudget) ? 1 : 0,
+        ];
+      },
+      filterCategories: [
+        managingAgency === null ? fullAgencyAcronymList : [managingAgency],
+        [1],
+      ],
+      getFillColor: ({ properties }) => {
+        const { managingCodeCapitalProjectId } = properties;
+        switch (managingCodeCapitalProjectId) {
+          case `${managingCode}${capitalProjectId}`:
+            return [56, 178, 172, 166];
+          default:
+            return [217, 107, 39, 166];
+        }
+      },
+      getPointRadius: 5,
+      getLineColor: [255, 255, 255, 255],
+      getLineWidth: 1,
+      onHover: (data) => {
+        const managingCodeCapitalProjectId =
+          data.object?.properties?.managingCodeCapitalProjectId;
+        if (data.index === -1) {
+          setHoveredOverProject(null);
+        } else if (managingCodeCapitalProjectId !== undefined) {
+          setHoveredOverProject(managingCodeCapitalProjectId);
+        }
+      },
+      onClick: (data) => {
+        const managingCodeCapitalProjectId =
+          data.object?.properties?.managingCodeCapitalProjectId;
+
+        if (managingCodeCapitalProjectId === undefined) return;
+        // Avoid adding the same capital project to the history stack
+        if (
+          managingCodeCapitalProjectId === `${managingCode}${capitalProjectId}`
+        )
+          return;
+        const [nextManagingCode, nextCapitalProjectId] = [
+          managingCodeCapitalProjectId.slice(0, 3),
+          managingCodeCapitalProjectId.slice(3),
+        ];
+
+        const capitalProjectRouteSuffix = `capital-projects/${nextManagingCode}/${nextCapitalProjectId}`;
+        navigate({
+          pathname: `${endpointPrefix}${capitalProjectRouteSuffix}`,
+          search: `?${searchParams.toString()}`,
+        });
+      },
+      updateTriggers: {
+        getFillColor: [managingCode, capitalProjectId],
+        getPointColor: [managingCode, capitalProjectId],
+        getFilterCategory: [agencyBudget],
+      },
+      extensions: [
+        new MaskExtension(),
+        new DataFilterExtension({
+          filterSize: 1,
+          categorySize: 2,
+        }),
+      ],
+      maskId: `${districtId !== null ? "boundary-mvt" : ""}`,
+      maskByInstance: true, //doesn't seem to have an effect
+      maskInverted: false,
+    });
 
   return new MVTLayer<
     CapitalProjectProperties,

--- a/app/components/layers/useCityCouncilDistrictLayer.client.tsx
+++ b/app/components/layers/useCityCouncilDistrictLayer.client.tsx
@@ -19,11 +19,12 @@ export function useCityCouncilDistrictLayer() {
     id: "CityCouncilDistrict",
     data,
     visible: hasCityCouncilDistrict,
-    filled: false,
+    filled: true,
+    getFillColor: [119, 128, 190, 128],
     stroked: true,
     lineWidthUnits: "pixels",
     getLineWidth: 3,
-    getLineColor: [49, 151, 149],
+    getLineColor: [48, 66, 100],
     extensions: [new FlyToGeoJsonExtension()],
   });
 }

--- a/app/components/layers/useCityCouncilDistrictsLayer.client.tsx
+++ b/app/components/layers/useCityCouncilDistrictsLayer.client.tsx
@@ -1,16 +1,82 @@
 import { MVTLayer } from "@deck.gl/geo-layers";
-import { useSearchParams } from "react-router";
+import { useState } from "react";
+import { useUpdateSearchParams } from "~/utils/utils";
+import { DistrictId, DistrictType } from "~/utils/types";
 import { env } from "~/utils/env";
 
-const { zoningApiUrl } = env;
+const { zoningApiUrl, facDbPhase1 } = env;
 export interface CityCouncilDistrictProperties {
   layerName: string;
   id: string;
 }
 
 export function useCityCouncilDistrictsLayer() {
-  const [searchParams] = useSearchParams();
-  const districtType = searchParams.get("districtType");
+  const [searchParams, updateSearchParams] = useUpdateSearchParams();
+  const [isHovered, setIsHovered] = useState<string | undefined>();
+  const districtType = searchParams.get("districtType") as DistrictType;
+  const districtId = searchParams.get("districtId") as DistrictId;
+
+  if (facDbPhase1 == "ON")
+    return new MVTLayer<CityCouncilDistrictProperties>({
+      id: "CityCouncilDistricts",
+      data: [`${zoningApiUrl}/api/city-council-districts/{z}/{x}/{y}.pbf`],
+      visible: districtType === "ccd",
+      uniqueIdProperty: "boroughIdCityCouncilDistrictId",
+      pickable: true,
+      getPointRadius: 5,
+      filled: true,
+      getFillColor: [0, 0, 0, 0],
+      getLineColor: ({
+        properties,
+      }: {
+        properties: CityCouncilDistrictProperties;
+      }) => {
+        if (properties.id === isHovered) {
+          return [250, 255, 0];
+        }
+        return [113, 128, 150, 0];
+      },
+      getLineWidth: 3,
+      lineWidthUnits: "pixels",
+      onHover: (info) => {
+        if (info.picked) {
+          if (info?.object.properties.id === districtId) {
+            setIsHovered(undefined);
+          } else {
+            setIsHovered(info.object.properties.id);
+          }
+        }
+      },
+      onClick: (info) => {
+        const newDistrictId = info.object.properties.id;
+        if (districtId === newDistrictId) {
+          updateSearchParams({
+            districtId: null,
+          });
+        } else {
+          updateSearchParams({
+            districtId: info.object.properties.id,
+          });
+        }
+      },
+      pointType: "text",
+      getText: ({
+        properties,
+      }: {
+        properties: CityCouncilDistrictProperties;
+      }) => properties.id,
+      getTextColor: [98, 98, 98, 255],
+      textFontFamily: "Helvetica Neue, Arial, sans-serif",
+      getTextSize: 15,
+      textFontSettings: {
+        sdf: true,
+      },
+      textOutlineColor: [255, 255, 255, 255],
+      textOutlineWidth: 2,
+      updateTriggers: {
+        getLineColor: isHovered,
+      },
+    });
 
   return new MVTLayer<CityCouncilDistrictProperties>({
     id: "CityCouncilDistricts",

--- a/app/components/layers/useCityCouncilDistrictsOutlinesLayer.client.tsx
+++ b/app/components/layers/useCityCouncilDistrictsOutlinesLayer.client.tsx
@@ -1,0 +1,29 @@
+import { MVTLayer } from "@deck.gl/geo-layers";
+import { useSearchParams } from "react-router";
+import { env } from "~/utils/env";
+
+const { zoningApiUrl } = env;
+export interface CityCouncilDistrictProperties {
+  layerName: string;
+  id: string;
+}
+
+export function useCityCouncilDistrictsOutlinesLayer() {
+  const [searchParams] = useSearchParams();
+  const districtType = searchParams.get("districtType");
+
+  return new MVTLayer<CityCouncilDistrictProperties>({
+    id: "CityCouncilDistrictsOutlines",
+    data: [`${zoningApiUrl}/api/city-council-districts/{z}/{x}/{y}.pbf`],
+    visible: districtType === "ccd",
+    uniqueIdProperty: "boroughIdCityCouncilDistrictId",
+    pickable: false,
+    getLineColor: [113, 128, 150, 255],
+    getLineWidth: 1,
+    lineWidthUnits: "pixels",
+    pointType: "text",
+    getFillColor: [0, 0, 0, 0],
+    autoHighlight: true,
+    highlightColor: [0, 0, 0, 0],
+  });
+}

--- a/app/components/layers/useCommunityBoardBudgetRequestsLayer.client.tsx
+++ b/app/components/layers/useCommunityBoardBudgetRequestsLayer.client.tsx
@@ -3,6 +3,8 @@ import { useNavigate, useParams, useSearchParams } from "react-router";
 import {
   DataFilterExtension,
   DataFilterExtensionProps,
+  MaskExtension,
+  MaskExtensionProps,
 } from "@deck.gl/extensions";
 import type { Feature, Geometry } from "geojson";
 import {
@@ -17,7 +19,7 @@ import { env } from "~/utils/env";
 import { CommunityBoardBudgetRequestType } from "~/gen";
 import { IconClusterLayer } from "./icon-cluster-layer";
 
-const { zoningApiUrl } = env;
+const { zoningApiUrl, facDbPhase1 } = env;
 
 export type CommunityBoardBudgetRequestProperties = {
   id: string;
@@ -85,6 +87,171 @@ export function useCommunityBoardBudgetRequestsLayer(opts: {
     7: "parks",
     8: "other",
   };
+
+  if (facDbPhase1 == "ON")
+    return new MVTLayer<
+      CommunityBoardBudgetRequestProperties,
+      DataFilterExtensionProps<
+        Feature<Geometry, CommunityBoardBudgetRequestProperties>
+      > &
+        MaskExtensionProps
+    >({
+      id: "communityBoardBudgetRequests",
+      data: [
+        `${zoningApiUrl}/api/${endpointPrefix}community-board-budget-requests/{z}/{x}/{y}.pbf`,
+      ],
+      visible,
+      uniqueIdProperty: "id",
+      getFillColor: ({ properties }) => {
+        if (properties.id === hoveredCbbr) {
+          return [43, 108, 176, 100];
+        } else {
+          return [43, 108, 176, 153];
+        }
+      },
+      pointType: "icon",
+      getLineColor: [255, 255, 255, 255],
+      getLineWidth: 1,
+      iconAtlas: `/policy-area-icons/all-icons.png`,
+      iconMapping: `/mapping.json`,
+      pickable: true,
+      updateTriggers: {
+        getFillColor: [hoveredCbbr],
+        getIcon: [cbbrId],
+        getIconSize: [cbbrId],
+        getIconColor: [hoveredCbbr],
+        getFilterValue: [
+          cbbrPolicyAreaId,
+          cbbrNeedGroupId,
+          cbbrAgencyInitials,
+          cbbrAgencyCategoryResponseIds,
+        ],
+      },
+      onHover: (info) => {
+        if (info.index === -1) {
+          setHoveredOverCbbr(null);
+        } else {
+          setHoveredOverCbbr(info.object?.properties?.id ?? null);
+        }
+      },
+      onClick: (data) => {
+        if (data.object.properties.cluster !== true) {
+          const individualCbbrId = data.object?.properties?.id;
+          if (individualCbbrId === undefined) return;
+          if (individualCbbrId === `${cbbrId}`) return;
+          const cbbrRouteSuffix = `/community-board-budget-requests/${individualCbbrId}`;
+          navigate({
+            pathname: `${cbbrRouteSuffix}`,
+            search: `?${searchParams.toString()}`,
+          });
+        } else {
+          onClusterClick(
+            data.object.properties.expansionZoom,
+            data.object.geometry.coordinates[1],
+            data.object.geometry.coordinates[0],
+          );
+        }
+      },
+      iconSizeScale: 25,
+      binary: false,
+      getIcon: (d: { properties: CommunityBoardBudgetRequestProperties }) => {
+        if (d.properties.cluster !== true) {
+          const icon = policyAreaIconsMap[d.properties.policyAreaId];
+          if (cbbrId === d.properties.id) {
+            return null;
+          } else {
+            return `${icon}`;
+          }
+        } else {
+          const size = d.properties.point_count;
+          if (size === 0) {
+            return `marker-1`;
+          }
+          if (size < 10) {
+            return `marker-${size}`;
+          }
+          if (size < 150) {
+            return `marker-${Math.floor(size / 10)}0`;
+          }
+          return "marker-150";
+        }
+      },
+      getIconSize: (d: {
+        properties: CommunityBoardBudgetRequestProperties;
+      }) => {
+        if (d.properties.cluster !== true) {
+          if (cbbrId === d.properties.id) {
+            return 1.2;
+          } else {
+            return 1;
+          }
+        } else {
+          return Math.min(150, d.properties.point_count) / 100 + 1;
+        }
+      },
+      getIconColor: (d: {
+        properties: CommunityBoardBudgetRequestProperties;
+      }) => {
+        if (d.properties.id === hoveredCbbr) {
+          return [255, 255, 255, 200];
+        } else {
+          return [43, 108, 176, 255];
+        }
+      },
+      getFilterValue: (d) => {
+        // Do not filter points, they are filtered in Icon sublayer
+        if (d.geometry.type === "Point") return 1;
+
+        // Filter out if it does not match one of the user selected filters
+        if (
+          cbbrPolicyAreaId !== null &&
+          d.properties.policyAreaId !== parseInt(cbbrPolicyAreaId)
+        )
+          return 0;
+
+        if (
+          cbbrNeedGroupId !== null &&
+          d.properties.needGroupId !== parseInt(cbbrNeedGroupId)
+        )
+          return 0;
+
+        if (
+          cbbrAgencyInitials !== null &&
+          d.properties.agencyInitials !== cbbrAgencyInitials
+        )
+          return 0;
+
+        if (
+          cbbrAgencyCategoryResponseIds.length > 0 &&
+          !cbbrAgencyCategoryResponseIds.includes(
+            parseInt(d.properties.agencyCategoryReponseId),
+          )
+        )
+          return 0;
+
+        // Otherwise, display it
+        return 1;
+      },
+      filterRange: [1, 1],
+      _subLayerProps: {
+        "points-icon": {
+          type: IconClusterLayer<CommunityBoardBudgetRequestProperties>,
+          policyAreaId: cbbrPolicyAreaId ? parseInt(cbbrPolicyAreaId) : null,
+          needGroupId: cbbrNeedGroupId ? parseInt(cbbrNeedGroupId) : null,
+          agencyInitials: cbbrAgencyInitials,
+          agencyCategoryResponseIds: cbbrAgencyCategoryResponseIds,
+        },
+      },
+      extensions: [
+        new MaskExtension(),
+        new DataFilterExtension({
+          filterSize: 1,
+        }),
+      ],
+      maskId: `${districtId !== null ? "boundary-mvt" : ""}`,
+      maskByInstance: true, //doesn't seem to have an effect
+      maskInverted: false,
+    });
 
   return new MVTLayer<
     CommunityBoardBudgetRequestProperties,

--- a/app/components/layers/useCommunityDistrictLayer.client.tsx
+++ b/app/components/layers/useCommunityDistrictLayer.client.tsx
@@ -21,11 +21,12 @@ export function useCommunityDistrictLayer() {
     id: "CommunityDistrict",
     data,
     visible: hasCommunityDistrict,
-    filled: false,
+    filled: true,
+    getFillColor: [119, 128, 190, 128],
     stroked: true,
     lineWidthUnits: "pixels",
     getLineWidth: 3,
-    getLineColor: [49, 151, 149],
+    getLineColor: [48, 66, 100],
     extensions: [new FlyToGeoJsonExtension()],
   });
 }

--- a/app/components/layers/useCommunityDistrictsLayer.client.tsx
+++ b/app/components/layers/useCommunityDistrictsLayer.client.tsx
@@ -1,8 +1,10 @@
 import { MVTLayer } from "@deck.gl/geo-layers";
-import { useSearchParams } from "react-router";
+import { useState } from "react";
+import { useUpdateSearchParams } from "~/utils/utils";
+import { BoroughId, DistrictId, DistrictType } from "~/utils/types";
 import { env } from "~/utils/env";
 
-const { zoningApiUrl } = env;
+const { zoningApiUrl, facDbPhase1 } = env;
 export interface CommunityDistrictProperties {
   boroughIdCommunityDistrictId: string;
   layerName: string;
@@ -10,8 +12,95 @@ export interface CommunityDistrictProperties {
 }
 
 export function useCommunityDistrictsLayer() {
-  const [searchParams] = useSearchParams();
-  const districtType = searchParams.get("districtType");
+  const [searchParams, updateSearchParams] = useUpdateSearchParams();
+  const [isHovered, setIsHovered] = useState<string | undefined>();
+  const districtType = searchParams.get("districtType") as DistrictType;
+  const boroughId = searchParams.get("boroughId") as BoroughId;
+  const districtId = searchParams.get("districtId") as DistrictId;
+
+  if (facDbPhase1 == "ON")
+    return new MVTLayer<CommunityDistrictProperties>({
+      id: "CommunityDistricts",
+      data: [`${zoningApiUrl}/api/community-districts/{z}/{x}/{y}.pbf`],
+      visible: districtType === "cd" || districtType === null,
+      uniqueIdProperty: "boroughIdCommunityDistrictId",
+      pickable: true,
+      getPointRadius: 5,
+      filled: true,
+      getLineColor: ({
+        properties,
+      }: {
+        properties: CommunityDistrictProperties;
+      }) => {
+        if (properties.boroughIdCommunityDistrictId === isHovered) {
+          return [250, 255, 0];
+        }
+        return [113, 128, 150, 0];
+      },
+      getLineWidth: 3,
+      lineWidthUnits: "pixels",
+      pointType: "text",
+      getText: ({
+        properties,
+      }: {
+        properties: CommunityDistrictProperties;
+      }) => {
+        // If CommunityDistrictId > 18, the area represents a Park, not a Community District
+        if (parseInt(properties.boroughIdCommunityDistrictId.slice(-2)) > 18) {
+          return null;
+        }
+        return `${properties.abbr} ${parseInt(properties.boroughIdCommunityDistrictId.slice(-2))}`;
+      },
+      onHover: (info) => {
+        if (info.picked) {
+          if (
+            info?.object.properties.boroughIdCommunityDistrictId ===
+              `${boroughId}${districtId}` ||
+            parseInt(
+              info?.object.properties.boroughIdCommunityDistrictId.slice(-2),
+            ) > 18
+          ) {
+            setIsHovered(undefined);
+          } else {
+            setIsHovered(info.object.properties.boroughIdCommunityDistrictId);
+          }
+        }
+      },
+      onClick: (info) => {
+        const newBoroughId =
+          info.object.properties.boroughIdCommunityDistrictId[0];
+        const newDistrictId =
+          info.object.properties.boroughIdCommunityDistrictId.slice(1);
+        if (newDistrictId <= 18) {
+          if (boroughId === newBoroughId && districtId === newDistrictId) {
+            updateSearchParams({
+              districtType: "cd",
+              boroughId: null,
+              districtId: null,
+            });
+          } else {
+            updateSearchParams({
+              districtType: "cd",
+              boroughId: info.object.properties.boroughIdCommunityDistrictId[0],
+              districtId:
+                info.object.properties.boroughIdCommunityDistrictId.slice(1),
+            });
+          }
+        }
+      },
+      getFillColor: [0, 0, 0, 0],
+      getTextColor: [98, 98, 98, 255],
+      textFontFamily: "Helvetica Neue, Arial, sans-serif",
+      getTextSize: 15,
+      textFontSettings: {
+        sdf: true,
+      },
+      textOutlineColor: [255, 255, 255, 255],
+      textOutlineWidth: 2,
+      updateTriggers: {
+        getLineColor: isHovered,
+      },
+    });
 
   return new MVTLayer<CommunityDistrictProperties>({
     id: "CommunityDistricts",

--- a/app/components/layers/useCommunityDistrictsOutlinesLayer.client.tsx
+++ b/app/components/layers/useCommunityDistrictsOutlinesLayer.client.tsx
@@ -1,0 +1,41 @@
+import { MVTLayer } from "@deck.gl/geo-layers";
+import { useUpdateSearchParams } from "~/utils/utils";
+import { DistrictType } from "~/utils/types";
+import { env } from "~/utils/env";
+
+const { zoningApiUrl } = env;
+export interface CommunityDistrictProperties {
+  boroughIdCommunityDistrictId: string;
+  layerName: string;
+  abbr: string | null;
+}
+
+export function useCommunityDistrictsOutlinesLayer() {
+  const [searchParams] = useUpdateSearchParams();
+  const districtType = searchParams.get("districtType") as DistrictType;
+
+  return new MVTLayer<CommunityDistrictProperties>({
+    id: "CommunityDistrictsOutlines",
+    data: [`${zoningApiUrl}/api/community-districts/{z}/{x}/{y}.pbf`],
+    visible: districtType === "cd" || districtType === null,
+    uniqueIdProperty: "boroughIdCommunityDistrictId",
+    pickable: false,
+    getLineColor: [113, 128, 150, 255],
+    getLineWidth: ({
+      properties,
+    }: {
+      properties: CommunityDistrictProperties;
+    }) => {
+      // If CommunityDistrictId > 18, the area represents a Park, not a Community District
+      if (parseInt(properties.boroughIdCommunityDistrictId.slice(-2)) > 18) {
+        return 0;
+      }
+      return 1;
+    },
+    lineWidthUnits: "pixels",
+    pointType: "text",
+    getFillColor: [0, 0, 0, 0],
+    autoHighlight: true,
+    highlightColor: [0, 0, 0, 0],
+  });
+}

--- a/app/layouts/MapPage.tsx
+++ b/app/layouts/MapPage.tsx
@@ -3,7 +3,6 @@ import {
   GridItem,
   Accordion,
   Box,
-  Collapse,
   AccordionItem,
   AccordionButton,
   Heading,
@@ -12,6 +11,9 @@ import {
   Text,
   HStack,
   Link,
+  Tab,
+  TabList,
+  Tabs,
 } from "@nycplanning/streetscape";
 import {
   Outlet,
@@ -39,10 +41,10 @@ import {
   CommunityBoardBudgetRequestAgencyCategoryResponseId,
   CommunityBoardBudgetRequestNeedGroupId,
   CommunityBoardBudgetRequestPolicyAreaId,
+  DistrictId,
   DistrictType,
 } from "../utils/types";
 import { HowToUseThisTool } from "../components/AdminDropdownContent/HowToUseThisTool";
-import { MapLayersPanel } from "../components/AdminMapLayersPanel";
 import {
   CapitalProjectLayerToggle,
   CommunityBoardBudgetRequestLayerToggle,
@@ -53,6 +55,7 @@ import type { RootContextType } from "../root";
 import { MapViewControls } from "~/components/MapViewControls";
 import { SearchByCbbrMenu } from "~/components/SearchByCbbrMenu";
 import { useState } from "react";
+import { MapLayersPanel } from "~/components/AdminMapLayersPanel";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
@@ -246,6 +249,357 @@ export default function MapPage() {
     });
   };
 
+  const districtType = searchParams.get("districtType") as DistrictType;
+  const districtId = searchParams.get("districtId") as DistrictId;
+  const boroughId = searchParams.get("boroughId") as BoroughId;
+
+  const getDefaultIndex = (type: DistrictType | null) => {
+    switch (type) {
+      case "ccd":
+        return 1;
+      default:
+        return 0;
+    }
+  };
+
+  const [savedGeoSelection, setSavedGeoSelection] = useState<{
+    cd: { boroughId: BoroughId; districtId: DistrictId } | undefined;
+    ccd: { districtId: DistrictId } | undefined;
+  }>({ cd: undefined, ccd: undefined });
+
+  if (env.facDbPhase1 == "ON")
+    return (
+      <>
+        <GridItem
+          gridColumn={"1 / -1"}
+          gridRow={{
+            base: "2 / 7",
+            md: "2 / -1",
+          }}
+        >
+          <Atlas
+            viewState={viewState}
+            setViewState={(MapViewState) => setViewState(MapViewState)}
+            showCapitalProjects={showCapitalProjects}
+            showCbbr={showCbbr}
+            hoveredOverItem={hoveredOverItem}
+            setHoveredOverItem={setHoveredOverItem}
+          />{" "}
+        </GridItem>
+        <GridItem
+          bgColor="white"
+          borderRadius="lg"
+          gridRowStart={3}
+          gridColumn={{
+            base: "col-start / span 8",
+            md: "col-start / span 7",
+            xl: "5 / span 5",
+            "2xl": "4 / span 7",
+          }}
+          height={"fit-content"}
+        >
+          <Tabs
+            variant={"mapControl"}
+            style={{
+              boxShadow:
+                "0 4px 6px -1px rgba(0, 0, 0, 0.10), 0 2px 4px -1px rgba(0, 0, 0, 0.06)",
+              borderRadius: "lg",
+            }}
+            whiteSpace={"nowrap"}
+            width={{ base: "100%", md: "fit-content" }}
+            defaultIndex={getDefaultIndex(districtType)}
+          >
+            <TabList
+              key={"TabList"}
+              display={{ base: "grid", md: "inline-grid" }}
+              gridAutoColumns={"1fr"}
+            >
+              <Tab
+                key={"Community Districts"}
+                fontSize={{
+                  base: "xs",
+                  md: "sm",
+                }}
+                gridRow={1}
+                onClick={() => {
+                  if (districtId !== null)
+                    setSavedGeoSelection({
+                      ...savedGeoSelection,
+                      ccd: { districtId },
+                    });
+                  if (savedGeoSelection.cd === undefined) {
+                    updateSearchParams({
+                      districtType: "cd",
+                      boroughId: null,
+                      districtId: null,
+                    });
+                  } else {
+                    updateSearchParams({
+                      districtType: "cd",
+                      boroughId: savedGeoSelection.cd.boroughId,
+                      districtId: savedGeoSelection.cd.districtId,
+                    });
+                  }
+                }}
+              >
+                Community Districts
+              </Tab>
+              <Tab
+                key={"City Council"}
+                fontSize={{
+                  base: "xs",
+                  md: "sm",
+                }}
+                gridRow={1}
+                onClick={() => {
+                  if (districtId !== null)
+                    setSavedGeoSelection({
+                      ...savedGeoSelection,
+                      cd: { boroughId, districtId },
+                    });
+                  if (savedGeoSelection.ccd === undefined) {
+                    updateSearchParams({
+                      districtType: "ccd",
+                      boroughId: null,
+                      districtId: null,
+                    });
+                  } else {
+                    updateSearchParams({
+                      districtType: "ccd",
+                      boroughId: null,
+                      districtId: savedGeoSelection.ccd.districtId,
+                    });
+                  }
+                }}
+              >
+                City Council
+              </Tab>
+            </TabList>
+          </Tabs>
+        </GridItem>
+        <GridItem
+          gridColumn={{
+            base: "col-start / span 7",
+            md: "col-start / span 5",
+            lg: "col-start / span 4",
+            xl: "col-start / span 3",
+            "2xl": "col-start / span 2",
+          }}
+          gridRow={{
+            base: "5 / row-end",
+            md: "5 / row-end",
+            xl: "3 / span 3",
+          }}
+          height={"fit-content"}
+          maxHeight={"100%"}
+          zIndex={"1"}
+          sx={{
+            scrollbarWidth: "none",
+          }}
+        >
+          <Flex
+            direction={"column"}
+            width={{ base: "100%", lg: "auto" }}
+            alignItems={"center"}
+            flexShrink={{ lg: 0 }}
+            maxHeight={{
+              base: "82vh",
+              lg: "84vh",
+              xl: "89vh",
+            }}
+            backgroundColor={"white"}
+            borderRadius={10}
+            overflowY={"scroll"}
+            padding={4}
+            sx={{
+              scrollbarWidth: "none",
+            }}
+            boxShadow={"0 2px 8px 0 rgba(0, 0, 0, 0.20)"}
+          >
+            <Accordion allowMultiple defaultIndex={[0]} width={"100%"}>
+              <AccordionItem borderTop={"none"} borderBottom={"none"}>
+                <AccordionButton p={0} aria-label="Toggle layers panel">
+                  <Heading
+                    flex="1"
+                    textAlign="left"
+                    fontSize="md"
+                    fontWeight="bold"
+                    lineHeight="32px"
+                    pb={0}
+                  >
+                    Capital Planning Data
+                  </Heading>
+                  <AccordionIcon />
+                </AccordionButton>
+                <AccordionPanel px={0} pt={2} pb={0}>
+                  <Box>
+                    <Accordion
+                      allowMultiple
+                      index={filtersAccordionIndex}
+                      width={"100%"}
+                    >
+                      <Box
+                        display={"flex"}
+                        flexDirection={"column"}
+                        paddingBottom={2}
+                      >
+                        <Text fontSize={"xs"}>Layer Filters</Text>
+                        <HStack
+                          fontSize={"sm"}
+                          paddingBottom={2}
+                          width={"100%"}
+                          justifyContent={"space-between"}
+                          whiteSpace={"nowrap"}
+                          flexWrap={"wrap"}
+                          rowGap={0}
+                        >
+                          <HStack>
+                            <Link
+                              color={"primary.600"}
+                              textDecor={"underline"}
+                              cursor={"pointer"}
+                              onClick={() =>
+                                setFiltersAccordionIndex([0, 1, 2])
+                              }
+                            >
+                              Expand All
+                            </Link>
+                            <Text>|</Text>
+                            <Link
+                              color={"primary.600"}
+                              textDecor={"underline"}
+                              cursor={"pointer"}
+                              onClick={() => setFiltersAccordionIndex([])}
+                            >
+                              Collapse All
+                            </Link>
+                          </HStack>
+                          <Link
+                            color={"primary.600"}
+                            textDecor={"underline"}
+                            cursor={"pointer"}
+                            onClick={() =>
+                              updateSearchParams({
+                                managingAgency: null,
+                                agencyBudget: null,
+                                commitmentsTotalMin: null,
+                                commitmentsTotalMax: null,
+                                cbbrPolicyAreaId: null,
+                                cbbrNeedGroupId: null,
+                                cbbrAgencyInitials: null,
+                                cbbrAgencyCategoryResponseIds: null,
+                              })
+                            }
+                          >
+                            Clear All
+                          </Link>
+                        </HStack>
+                        <Box display={"flex"} flexDirection={"column"} gap={2}>
+                          <CapitalProjectLayerToggle />
+                          <SearchByAttributeMenu
+                            agencies={managingAgencies}
+                            projectTypes={agencyBudgets}
+                            onClear={clearCapitalProjectFilters}
+                            updateFiltersAccordion={updateFiltersAccordion(0)}
+                          />
+                          <CommunityBoardBudgetRequestLayerToggle />
+                          <SearchByCbbrMenu
+                            cbbrPolicyAreas={cbbrPolicyAreas}
+                            cbbrNeedGroups={cbbrNeedGroups}
+                            cbbrAgencies={cbbrAgencies}
+                            cbbrAgencyCategoryResponses={
+                              cbbrAgencyCategoryResponses
+                            }
+                            cbbrAgencyCategoryResponseIds={
+                              cbbrAgencyCategoryResponseIds
+                            }
+                            onClear={clearCbbrProjectFilters}
+                            updateFiltersAccordion={updateFiltersAccordion(1)}
+                          />
+                          <CommunityBoardBudgetRequestLegend
+                            updateFiltersAccordion={updateFiltersAccordion(2)}
+                          />
+                        </Box>
+                      </Box>
+                    </Accordion>
+                    <Box display={"flex"} flexDirection={"column"} gap={2}>
+                      <FilterMenu
+                        boroughs={boroughs}
+                        communityDistricts={communityDistricts}
+                        cityCouncilDistricts={cityCouncilDistricts}
+                      />
+                    </Box>
+
+                    <HowToUseThisTool />
+                  </Box>
+                </AccordionPanel>
+              </AccordionItem>
+            </Accordion>
+          </Flex>
+        </GridItem>
+        <GridItem
+          gridColumnStart={{ base: 9, md: 7, lg: 6, xl: 5, "2xl": 4 }}
+          gridRow={{
+            base: "5 / span 1",
+          }}
+          width={"fit-content"}
+          height={"fit-content"}
+        >
+          <MapViewControls
+            viewState={viewState}
+            setViewState={setViewState}
+            minZoom={MIN_ZOOM}
+            maxZoom={MAX_ZOOM}
+          />
+        </GridItem>
+        <GridItem
+          gridColumn={{
+            base: "1 / -1",
+            lg: "9 / span 5",
+            xl: "10 / col-end",
+            "2xl": "11 / col-end",
+          }}
+          gridRow={{
+            base: "3 / -1",
+            lg: "row-start / span 3",
+          }}
+          height={"100%"}
+          pointerEvents={"none"}
+          zIndex={"2"}
+          sx={{
+            scrollbarWidth: "none",
+          }}
+          overflowY={"scroll"}
+          display={"flex"}
+          flexDirection={"column"}
+          justifyContent={{ base: "end", lg: "start" }}
+        >
+          <Flex
+            width={"full"}
+            gap={3}
+            pointerEvents={"none"}
+            sx={{
+              "> *": {
+                pointerEvents: "auto",
+              },
+              scrollbarWidth: "none",
+            }}
+            direction={"column"}
+            flexShrink={{ lg: 0 }}
+            maxHeight={"full"}
+            justify={"end"}
+            backgroundColor={"white"}
+            borderRadius={10}
+            overflowY={"scroll"}
+            padding={4}
+            boxShadow={"0 8px 4px 0 rgba(0, 0, 0, 0.08)"}
+          >
+            <Outlet context={{ hoveredOverItem, setHoveredOverItem }} />
+          </Flex>
+        </GridItem>
+      </>
+    );
+
   return (
     <>
       <GridItem
@@ -275,6 +629,7 @@ export default function MapPage() {
           base: "row-start / row-end",
           md: "row-start / row-end",
           lg: "row-start / span 1",
+          xl: "3 / span 2",
         }}
         height={"fit-content"}
         maxHeight={"100%"}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -21,6 +21,7 @@ import { useEffect, useState } from "react";
 import { initializeMatomoTagManager } from "./utils/analytics";
 import { HeaderBar } from "./components/HeaderBar";
 import { INITIAL_VIEW_STATE } from "./components/atlas.client";
+import { env } from "~/utils/env";
 
 export const links: LinksFunction = () => {
   return [
@@ -104,10 +105,17 @@ export default function App() {
                 xl: "0 0.94dw",
                 "2xl": "0 0.78dw",
               }}
-              templateRows={{
-                base: "7dvh 2dvh [row-start] 1fr [row-end] 2dvh 7dvh",
-                md: "7dvh 2dvh [row-start] 1fr [row-end] 2dvh",
-              }}
+              templateRows={
+                env.facDbPhase1 == "ON"
+                  ? {
+                      base: "7dvh 2dvh [row-start] min-content 2dvh 1fr [row-end] 2dvh 7dvh",
+                      md: "7dvh 2dvh [row-start] min-content 2dvh 1fr [row-end] 2dvh",
+                    }
+                  : {
+                      base: "7dvh 2dvh [row-start] 1fr [row-end] 2dvh 7dvh",
+                      md: "7dvh 2dvh [row-start] 1fr [row-end] 2dvh",
+                    }
+              }
               height="100vh"
             >
               <HeaderBar clearSelections={clearAllFilters} />


### PR DESCRIPTION
- Implements [new district filtering UI](https://www.figma.com/design/syxdP7UMhpsgBnlD6hjvst/FacDB-Design?node-id=90-22649&p=f&m=dev) for existing Community Board and City Council District filtering
- Adds highlighting districts on hover, makes map districts selectable
- Changes map geo filtering to be performed on the Front-end using MaskExtension

<img width="1822" height="1121" alt="image" src="https://github.com/user-attachments/assets/06665504-e403-4fe0-a9e6-c5de47854214" />


This adds two new layers, which are necessary for the hover to work properly.  Without the new layers, the hover color for a district is frequently over-ridden by the standard color of an adjacent layer.  The new layers display the district boundaries, and sit beneath the existing layers, where the district boundaries have been made invisible unless the district is hovered.

Known issues:
- Cursor is pointer when hovering areas that are in Community Districts layer but are not Community Districts (ex. JFK)
- Issues with the border-radius of the filtering UI that will require a separate PR and update to Streetscape
   - https://github.com/NYCPlanning/ae-streetscape/pull/130

Closes #376 