### PR TITLE
375 Map Layers Panel Clear All

### DIFF
--- a/app/layouts/MapPage.tsx
+++ b/app/layouts/MapPage.tsx
@@ -332,23 +332,54 @@ export default function MapPage() {
                         paddingBottom={2}
                       >
                         <Text fontSize={"xs"}>Layer Filters</Text>
-                        <HStack fontSize={"sm"} paddingBottom={2}>
+                        <HStack
+                          fontSize={"sm"}
+                          paddingBottom={2}
+                          width={"100%"}
+                          justifyContent={"space-between"}
+                          whiteSpace={"nowrap"}
+                          flexWrap={"wrap"}
+                          rowGap={0}
+                        >
+                          <HStack>
+                            <Link
+                              color={"primary.600"}
+                              textDecor={"underline"}
+                              cursor={"pointer"}
+                              onClick={() =>
+                                setFiltersAccordionIndex([0, 1, 2])
+                              }
+                            >
+                              Expand All
+                            </Link>
+                            <Text>|</Text>
+                            <Link
+                              color={"primary.600"}
+                              textDecor={"underline"}
+                              cursor={"pointer"}
+                              onClick={() => setFiltersAccordionIndex([])}
+                            >
+                              Collapse All
+                            </Link>
+                          </HStack>
                           <Link
                             color={"primary.600"}
                             textDecor={"underline"}
                             cursor={"pointer"}
-                            onClick={() => setFiltersAccordionIndex([0, 1, 2])}
+                            onClick={() =>
+                              updateSearchParams({
+                                managingAgency: null,
+                                agencyBudget: null,
+                                commitmentsTotalMin: null,
+                                commitmentsTotalMax: null,
+                                cbbrPolicyAreaId: null,
+                                cbbrNeedGroupId: null,
+                                cbbrAgencyInitials: null,
+                                cbbrAgencyCategoryResponseIds: null,
+                              })
+                            }
                           >
-                            Expand All
-                          </Link>
-                          <Text>|</Text>
-                          <Link
-                            color={"primary.600"}
-                            textDecor={"underline"}
-                            cursor={"pointer"}
-                            onClick={() => setFiltersAccordionIndex([])}
-                          >
-                            Collapse All
+                            Clear All
                           </Link>
                         </HStack>
                         <Box display={"flex"} flexDirection={"column"} gap={2}>


### PR DESCRIPTION
Added the "Clear All" link.

<img width="256" height="136" alt="image" src="https://github.com/user-attachments/assets/9c231856-fad6-4055-8327-8042606918bc" />
<img width="337" height="106" alt="image" src="https://github.com/user-attachments/assets/96604726-b627-482d-b0fb-1a8fe656180c" />

As discussed with Natasha, "Expand All | Collapse All" stays on the left, with "Clear All" on the right or below on the left, depending on the width of the unit.  The containers should wrap, the text should not.

Closes #375 