### PR TITLE
392 [Bug]: CPP/CBBR - Filtered items are not appearing on the map.

### DIFF
--- a/app/components/layers/icon-cluster-layer.ts
+++ b/app/components/layers/icon-cluster-layer.ts
@@ -6,6 +6,7 @@ import type {
   PointFeature,
   ClusterFeature,
   ClusterProperties,
+  AnyProps,
 } from "supercluster";
 import type { UpdateParameters, PickingInfo } from "@deck.gl/core";
 
@@ -13,9 +14,18 @@ export type IconClusterLayerPickingInfo<DataT> = PickingInfo<
   DataT | (DataT & ClusterProperties)
 >;
 
+export interface IconClusterLayerProps {
+  policyAreaId: number | null;
+  needGroupId: number | null;
+  agencyInitials: string | null;
+  agencyCategoryResponseIds: number[] | [];
+}
+
 export class IconClusterLayer<
   PropertiesT extends Record<string, unknown> & { id: string },
-> extends CompositeLayer<Required<IconLayerProps<PropertiesT>>> {
+> extends CompositeLayer<
+  Required<IconLayerProps<PropertiesT>> & IconClusterLayerProps
+> {
   state!: {
     data: (PointFeature<PropertiesT> | ClusterFeature<PropertiesT>)[];
     index: Supercluster<PropertiesT, PropertiesT>;
@@ -28,10 +38,12 @@ export class IconClusterLayer<
 
   updateState({ props, oldProps, changeFlags }: UpdateParameters<this>) {
     const z = Math.floor(this.context.viewport.zoom);
+    // console.log(changeFlags)
 
     const rebuildIndex =
       changeFlags.dataChanged ||
       props.sizeScale !== oldProps.sizeScale ||
+      props.updateTriggers !== oldProps.updateTriggers ||
       z !== this.state.z;
     const minZoom = 10;
     const maxZoom = 15;
@@ -49,14 +61,71 @@ export class IconClusterLayer<
           return;
         },
       });
+
+      const {
+        policyAreaId,
+        needGroupId,
+        agencyInitials,
+        agencyCategoryResponseIds,
+      } = props as IconClusterLayerProps;
+
+      let filteredData = props.data as (
+        | (PointFeature<PropertiesT> & { __source: AnyProps })
+        | (ClusterFeature<PropertiesT> & { __source: AnyProps })
+      )[];
+
+      if (
+        policyAreaId !== oldProps.policyAreaId ||
+        needGroupId !== oldProps.needGroupId ||
+        agencyInitials !== oldProps.agencyInitials ||
+        agencyCategoryResponseIds.length !==
+          oldProps.agencyCategoryResponseIds.length
+      ) {
+        filteredData = (
+          props.data as (
+            | (PointFeature<PropertiesT> & { __source: AnyProps })
+            | (ClusterFeature<PropertiesT> & { __source: AnyProps })
+          )[]
+        ).filter((point) => {
+          // console.count("filter")
+          if (
+            policyAreaId !== null &&
+            point.__source.object.properties.policyAreaId !== policyAreaId
+          )
+            return false;
+
+          if (
+            needGroupId !== null &&
+            point.__source.object.properties.needGroupId !== needGroupId
+          )
+            return false;
+
+          if (
+            agencyInitials !== null &&
+            point.__source.object.properties.agencyInitials !== agencyInitials
+          )
+            return false;
+
+          if (
+            agencyCategoryResponseIds.length > 0 &&
+            agencyCategoryResponseIds.find(
+              point.__source.object.properties.agencyCategoryReponseId,
+            ) === undefined
+          )
+            return false;
+
+          return true;
+        });
+      }
+
       index.load(
-        (props.data as PropertiesT[]).map((d) => {
+        filteredData.map((d) => {
           return {
             type: "Feature",
             geometry: {
               type: "Point",
               coordinates: (
-                props.getPosition as unknown as (d: PropertiesT) => number[]
+                props.getPosition as unknown as (d: AnyProps) => number[]
               )(d),
             },
             properties: {
@@ -67,10 +136,8 @@ export class IconClusterLayer<
         }),
       );
       this.setState({ index });
-    }
-    if (rebuildIndex || z !== this.state.z) {
-      const _data = this.state.index.getClusters([-100, 0, 100, 100], z);
 
+      const _data = index.getClusters([-100, 0, 100, 100], z);
       const data = _data.map((d) => {
         const result = {
           id:
@@ -85,9 +152,21 @@ export class IconClusterLayer<
               d.properties.cluster === true
                 ? (d.properties as ClusterProperties).cluster_id.toString()
                 : d.properties.id,
-            expansionZoom: this.state.index.getClusterExpansionZoom(
+            expansionZoom: index.getClusterExpansionZoom(
               (d.properties as ClusterProperties).cluster_id,
             ),
+            collection:
+              d.properties.cluster === true && d.id !== undefined
+                ? [
+                    d.properties,
+                    ...index
+                      .getLeaves(
+                        typeof d.id === "string" ? parseInt(d.id) : d.id,
+                        Infinity,
+                      )
+                      .map((child) => child.properties),
+                  ]
+                : [],
           },
         };
         return result;

--- a/app/components/layers/useCommunityBoardBudgetRequestsLayer.client.tsx
+++ b/app/components/layers/useCommunityBoardBudgetRequestsLayer.client.tsx
@@ -1,10 +1,5 @@
 import { MVTLayer } from "@deck.gl/geo-layers";
-import {
-  useNavigate,
-  useParams,
-  useLoaderData,
-  useSearchParams,
-} from "react-router";
+import { useNavigate, useParams, useSearchParams } from "react-router";
 import {
   DataFilterExtension,
   DataFilterExtensionProps,
@@ -18,7 +13,6 @@ import {
   DistrictId,
   DistrictType,
 } from "../../utils/types";
-import { loader as mapPageLoader } from "../../layouts/MapPage";
 import { env } from "~/utils/env";
 import { CommunityBoardBudgetRequestType } from "~/gen";
 import { IconClusterLayer } from "./icon-cluster-layer";
@@ -54,7 +48,7 @@ export function useCommunityBoardBudgetRequestsLayer(opts: {
   const boroughId = searchParams.get("boroughId") as BoroughId;
   const districtId = searchParams.get("districtId") as DistrictId;
   const cbbrNeedGroupId = searchParams.get(
-    "cbbrNeedGroupIds",
+    "cbbrNeedGroupId",
   ) as CommunityBoardBudgetRequestNeedGroupId;
   const cbbrPolicyAreaId = searchParams.get(
     "cbbrPolicyAreaId",
@@ -91,23 +85,6 @@ export function useCommunityBoardBudgetRequestsLayer(opts: {
     7: "parks",
     8: "other",
   };
-  const loaderData = useLoaderData<typeof mapPageLoader>();
-
-  const fullAgencyList = loaderData.cbbrAgencies
-    ? loaderData.cbbrAgencies.map((data) => data.initials)
-    : [];
-
-  const fullNeedGroupList = loaderData.cbbrNeedGroups
-    ? loaderData.cbbrNeedGroups.map((data) => data.id)
-    : [];
-
-  const fullPolicyAreaList = loaderData.cbbrPolicyAreas
-    ? loaderData.cbbrPolicyAreas.map((data) => `Capital-${data.id}`)
-    : [];
-
-  const fullAgencyCategoryResponseList = loaderData.cbbrAgencyCategoryResponses
-    ? loaderData.cbbrAgencyCategoryResponses.map((data) => data.id)
-    : [];
 
   return new MVTLayer<
     CommunityBoardBudgetRequestProperties,
@@ -139,6 +116,12 @@ export function useCommunityBoardBudgetRequestsLayer(opts: {
       getIcon: [cbbrId],
       getIconSize: [cbbrId],
       getIconColor: [hoveredCbbr],
+      getFilterValue: [
+        cbbrPolicyAreaId,
+        cbbrNeedGroupId,
+        cbbrAgencyInitials,
+        cbbrAgencyCategoryResponseIds,
+      ],
     },
     onHover: (info) => {
       if (info.index === -1) {
@@ -209,39 +192,53 @@ export function useCommunityBoardBudgetRequestsLayer(opts: {
         return [43, 108, 176, 255];
       }
     },
-    getFilterCategory: (d) => {
-      const {
-        agencyInitials,
-        needGroupId,
-        policyAreaId,
-        agencyCategoryReponseId,
-        requestType,
-      } = d.properties;
-      return [
-        agencyInitials,
-        needGroupId,
-        `${requestType}-${policyAreaId}`,
-        agencyCategoryReponseId,
-      ];
+    getFilterValue: (d) => {
+      // Do not filter points, they are filtered in Icon sublayer
+      if (d.geometry.type === "Point") return 1;
+
+      // Filter out if it does not match one of the user selected filters
+      if (
+        cbbrPolicyAreaId !== null &&
+        d.properties.policyAreaId !== parseInt(cbbrPolicyAreaId)
+      )
+        return 0;
+
+      if (
+        cbbrNeedGroupId !== null &&
+        d.properties.needGroupId !== parseInt(cbbrNeedGroupId)
+      )
+        return 0;
+
+      if (
+        cbbrAgencyInitials !== null &&
+        d.properties.agencyInitials !== cbbrAgencyInitials
+      )
+        return 0;
+
+      if (
+        cbbrAgencyCategoryResponseIds.length > 0 &&
+        !cbbrAgencyCategoryResponseIds.includes(
+          parseInt(d.properties.agencyCategoryReponseId),
+        )
+      )
+        return 0;
+
+      // Otherwise, display it
+      return 1;
     },
-    filterCategories: [
-      cbbrAgencyInitials !== null ? [cbbrAgencyInitials] : fullAgencyList,
-      cbbrNeedGroupId !== null ? [cbbrNeedGroupId] : fullNeedGroupList,
-      cbbrPolicyAreaId !== null
-        ? [`Capital-${cbbrPolicyAreaId}`]
-        : fullPolicyAreaList,
-      cbbrAgencyCategoryResponseIds.length > 0
-        ? cbbrAgencyCategoryResponseIds
-        : fullAgencyCategoryResponseList,
-    ],
+    filterRange: [1, 1],
     _subLayerProps: {
       "points-icon": {
         type: IconClusterLayer<CommunityBoardBudgetRequestProperties>,
+        policyAreaId: cbbrPolicyAreaId ? parseInt(cbbrPolicyAreaId) : null,
+        needGroupId: cbbrNeedGroupId ? parseInt(cbbrNeedGroupId) : null,
+        agencyInitials: cbbrAgencyInitials,
+        agencyCategoryResponseIds: cbbrAgencyCategoryResponseIds,
       },
     },
     extensions: [
       new DataFilterExtension({
-        categorySize: 4,
+        filterSize: 1,
       }),
     ],
   });


### PR DESCRIPTION
It moves the filtering of the Icons to the `IconClusterLayer`, by passing the necessary properties as parameters and filtering the dataset before the `index.load()` occurs.  In order to filter the points separately from the polygons, `useCommunityBoardBudgetRequestsLayer` was refactored to filter by value, since filtering by category does not allow for the`OR` required to whitelist all of the points to pass on to the `IconClusterLayer`.

Closes #392 