### PR TITLE
Add Selected Locations Section to results panel

### DIFF
--- a/app/components/ClearFilter/index.tsx
+++ b/app/components/ClearFilter/index.tsx
@@ -1,13 +1,18 @@
 import { Button } from "@nycplanning/streetscape";
+import type { Property } from "csstype";
 
 export interface ClearFilterBtnProps {
   onClear: () => void;
   buttonLabel?: string;
+  textAlign?: Property.TextAlign;
+  verticalAlign?: string;
 }
 
 export function ClearFilterBtn({
   onClear,
   buttonLabel = "Reset Selections",
+  textAlign = "left",
+  verticalAlign = "initial",
 }: ClearFilterBtnProps) {
   const handleClear = () => {
     try {
@@ -26,11 +31,12 @@ export function ClearFilterBtn({
       variant="tertiarty"
       textDecoration={"underline"}
       color={"primary.600"}
-      textAlign={"left"}
+      textAlign={textAlign}
       role={"button"}
       minHeight={"unset"}
       marginY={3}
       padding={0}
+      verticalAlign={verticalAlign}
     >
       {buttonLabel}
     </Button>

--- a/app/components/SelectedLocations.tsx
+++ b/app/components/SelectedLocations.tsx
@@ -1,0 +1,142 @@
+import { Box, CloseIcon, Flex, Heading, Tag } from "@nycplanning/streetscape";
+import { useLoaderData } from "react-router";
+import { useUpdateSearchParams } from "~/utils/utils";
+import { loader } from "~/layouts/ResultsPanel";
+import { ClearFilterBtn } from "./ClearFilter";
+
+export function SelectedLocations() {
+  const {
+    boroughsResponse: { boroughs },
+  } = useLoaderData<typeof loader>();
+
+  const [searchParams, updateSearchParams] = useUpdateSearchParams();
+  const boundaryType = searchParams.get("boundaryType");
+  const boroughId = searchParams.get("boroughId");
+  const boundaryId = searchParams.get("boundaryId");
+
+  const boroughIds = searchParams.get("boroughIds");
+
+  const tagLabel = (() => {
+    if (boundaryType === "ccd" && boundaryId !== null) {
+      return (
+        <>
+          <span style={{ fontWeight: "bold" }}>City Council</span>
+          <span style={{ paddingRight: "2px" }}>{` | ${boundaryId}`}</span>
+        </>
+      );
+    }
+
+    const borough = boroughs.find((b) => b.id === (boroughId ?? boroughIds));
+
+    if (!borough) return null;
+
+    if (boundaryType === "cd" && boundaryId !== null) {
+      return (
+        <>
+          <span style={{ fontWeight: "bold" }}>{borough.title}</span>
+          <span style={{ paddingRight: "2px" }}>{` | CD ${boundaryId}`}</span>
+        </>
+      );
+    }
+
+    if (boundaryType === "borough") {
+      return <span style={{ fontWeight: "bold" }}>{borough.title}</span>;
+    }
+
+    return null;
+  })();
+
+  const clearSelections = () => {
+    updateSearchParams({
+      boundaryType: null,
+      boroughId: null,
+      boundaryId: null,
+      boroughIds: null,
+    });
+  };
+
+  const clearTag = () => {
+    if (boundaryType === "ccd") {
+      updateSearchParams({
+        boundaryType: null,
+        boundaryId: null,
+        boroughId: null,
+      });
+    } else if (boundaryType === "cd") {
+      updateSearchParams({
+        boundaryType: null,
+        boroughId: null,
+        boundaryId: null,
+      });
+    } else if (boundaryType === "borough") {
+      updateSearchParams({
+        boundaryType: null,
+        boroughIds: null,
+      });
+    }
+  };
+
+  return (
+    <Flex
+      direction="column"
+      gap={"10px"}
+      border={"1px solid"}
+      borderColor={"gray.300"}
+      borderRadius={"12px"}
+      background={"gray.50"}
+      padding={4}
+      height={"82px"}
+    >
+      <Flex alignItems={"flex-start"} justify={"space-between"} height={"20px"}>
+        <Box alignSelf={"center"}>
+          <Heading fontSize={"xs"} fontWeight={"bold"}>
+            SELECTED LOCATION
+          </Heading>
+        </Box>
+        <Box alignSelf={"center"}>
+          <ClearFilterBtn
+            textAlign={"right"}
+            verticalAlign={"text-bottom"}
+            onClear={clearSelections}
+            buttonLabel="Clear"
+          ></ClearFilterBtn>
+        </Box>
+      </Flex>
+
+      <Flex
+        justifyContent={"flex-start"}
+        alignItems={"center"}
+        height={"20px"}
+        padding={"2px 4px"}
+      >
+        {tagLabel !== null && (
+          <Tag
+            display={"flex"}
+            justifyContent={"space-between"}
+            alignItems={"center"}
+            gap={"4px"}
+            fontSize={"11px"}
+            borderRadius={"4px"}
+            background={"primary.100"}
+            color={"teal.700"}
+          >
+            <Box>{tagLabel}</Box>
+            <Box>
+              <CloseIcon
+                color={"teal.700"}
+                width={"8px"}
+                height={"8px"}
+                onClick={clearTag}
+                aria-label={"closeIcon"}
+                verticalAlign={"baseline"}
+                sx={{
+                  cursor: "pointer",
+                }}
+              />
+            </Box>
+          </Tag>
+        )}
+      </Flex>
+    </Flex>
+  );
+}

--- a/app/layouts/ResultsPanel.test.tsx
+++ b/app/layouts/ResultsPanel.test.tsx
@@ -1,12 +1,24 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import ResultsPanelMain from "./ResultsPanel";
-import { createRoutesStub } from "react-router";
+import { createRoutesStub, Outlet } from "react-router";
+import { useState } from "react";
 import {
   createFindAgencies200,
   createFindBoroughs200,
   createFindCapitalProjects200,
   createFindCommunityBoardBudgetRequests200,
 } from "~/gen/mocks";
+
+const ParentWithContext = () => {
+  const [hoveredOverItem, setHoveredOverItem] = useState<string | null>(null);
+  return <Outlet context={{ hoveredOverItem, setHoveredOverItem }} />;
+};
 
 describe("Results Panel", () => {
   const agenciesResponse = createFindAgencies200();
@@ -24,28 +36,30 @@ describe("Results Panel", () => {
 
   const Stub = createRoutesStub([
     {
-      path: "/capital-projects",
-      Component: ResultsPanelMain,
-      loader,
-      HydrateFallback: () => <></>,
-    },
-    {
-      path: "/community-board-budget-requests",
-      Component: ResultsPanelMain,
-      loader,
-      HydrateFallback: () => <></>,
+      path: "/",
+      Component: ParentWithContext,
+      children: [
+        {
+          path: "capital-projects",
+          Component: ResultsPanelMain,
+          loader,
+          HydrateFallback: () => <></>,
+        },
+        {
+          path: "community-board-budget-requests",
+          Component: ResultsPanelMain,
+          loader,
+          HydrateFallback: () => <></>,
+        },
+      ],
     },
   ]);
 
   it("should render capital projects", async () => {
     render(<Stub initialEntries={["/capital-projects"]} />);
-    await waitFor(() =>
-      screen.getByText(
-        `${capitalProjectsResponse.totalProjects + budgetRequestsResponse.totalBudgetRequests} Results`,
-      ),
-    );
-    await waitFor(() => screen.getByText(/Community Board Budget Requests/));
-    await waitFor(() => screen.getByText(/Capital Projects/));
+
+    await waitFor(() => screen.getAllByText(/Budget Requests/));
+    await waitFor(() => screen.getAllByText(/Capital Projects/));
     await waitFor(() => screen.getByText(/Export Data/));
   });
 
@@ -56,9 +70,7 @@ describe("Results Panel", () => {
         new RegExp(capitalProjectsResponse.totalProjects.toString()),
       ),
     );
-    const budgetRequestTab = screen.getByText(
-      /Community Board Budget Requests/,
-    );
+    const budgetRequestTab = screen.getByText(/Budget Requests/);
     await waitFor(() => budgetRequestTab.click());
     await waitFor(() =>
       screen.getByText(
@@ -69,12 +81,127 @@ describe("Results Panel", () => {
 
   it("should render community board budget requests", async () => {
     render(<Stub initialEntries={["/community-board-budget-requests"]} />);
-    await waitFor(() =>
-      screen.getByText(
-        `${budgetRequestsResponse.totalBudgetRequests + capitalProjectsResponse.totalProjects} Results`,
-      ),
+
+    await waitFor(() => screen.getAllByText(/Budget Requests/));
+    await waitFor(() => screen.getAllByText(/Capital Projects/));
+  });
+
+  it("selected location section should not render when no locations are selected", async () => {
+    render(<Stub initialEntries={["/capital-projects"]} />);
+    await waitFor(() => screen.getByText(/Results/));
+    expect(screen.queryByText("SELECTED LOCATION")).not.toBeInTheDocument();
+  });
+
+  it("selected location section should render ccd tag when boundaryType and boundaryId params are set", async () => {
+    render(
+      <Stub
+        initialEntries={["/capital-projects?boundaryType=ccd&boundaryId=50"]}
+      />,
     );
-    await waitFor(() => screen.getByText(/Community Board Budget Requests/));
-    await waitFor(() => screen.getByText(/Capital Projects/));
+    await waitFor(() => screen.getByText("SELECTED LOCATION"));
+    await waitFor(() => screen.getByText("City Council"));
+    await waitFor(() => screen.getByText(/\| 50/));
+  });
+
+  it("selected location section should render cd tag with borough and district when cd params are set", async () => {
+    const [{ id, title }] = boroughsResponse.boroughs;
+
+    render(
+      <Stub
+        initialEntries={[
+          `/capital-projects?boundaryType=cd&boroughId=${id}&boundaryId=01`,
+        ]}
+      />,
+    );
+    await waitFor(() => screen.getByText("SELECTED LOCATION"));
+    await waitFor(() => screen.getAllByText(title));
+    await waitFor(() => screen.getAllByText(/\| CD 01/));
+  });
+
+  it("selected location section should render borough tag when borough params are set", async () => {
+    const [{ id, title }] = boroughsResponse.boroughs;
+
+    render(
+      <Stub
+        initialEntries={[
+          `/capital-projects?boundaryType=borough&boroughIds=${id}`,
+        ]}
+      />,
+    );
+    await waitFor(() => screen.getByText("SELECTED LOCATION"));
+    await waitFor(() => screen.getByText(title));
+  });
+
+  it("clicking the tag X on ccd tag clears ccd params from the url", async () => {
+    render(
+      <Stub
+        initialEntries={[`/capital-projects?boundaryType=ccd&boundaryId=50`]}
+      />,
+    );
+    await waitFor(() => screen.getByText("City Council"));
+    const closeIcon = screen.getByLabelText("closeIcon");
+    await act(() => fireEvent.click(closeIcon));
+    await waitFor(() =>
+      expect(screen.queryByText("City Council")).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText("SELECTED LOCATION")).not.toBeInTheDocument();
+  });
+
+  it("in the selected location section, clicking the tag X on cd tag clears cd params from the url", async () => {
+    const [{ id, title }] = boroughsResponse.boroughs;
+
+    render(
+      <Stub
+        initialEntries={[
+          `/capital-projects?boundaryType=cd&boroughId=${id}&boundaryId=01`,
+        ]}
+      />,
+    );
+
+    await waitFor(() => screen.getByText("SELECTED LOCATION"));
+    await waitFor(() => screen.getByText(title));
+    await waitFor(() => screen.getByText(/\| CD 01/));
+    const closeIcon = screen.getByLabelText("closeIcon");
+    await act(() => fireEvent.click(closeIcon));
+    await waitFor(() =>
+      expect(screen.queryByText("SELECTED LOCATION")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("in the selected location section, clicking the tag X on borough tag clears borough params from the url", async () => {
+    const [{ id, title }] = boroughsResponse.boroughs;
+
+    render(
+      <Stub
+        initialEntries={[
+          `/capital-projects?boundaryType=borough&boroughIds=${id}`,
+        ]}
+      />,
+    );
+
+    await waitFor(() => screen.getByText("SELECTED LOCATION"));
+    await waitFor(() => screen.getByText(title));
+    const closeIcon = screen.getByLabelText("closeIcon");
+    await act(() => fireEvent.click(closeIcon));
+    await waitFor(() =>
+      expect(screen.queryByText("SELECTED LOCATION")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("in the selected location section, clicking Clear removes all boundary params and hides selected location section", async () => {
+    const [{ id, title }] = boroughsResponse.boroughs;
+
+    render(
+      <Stub
+        initialEntries={[
+          `/capital-projects?boundaryType=cd&boroughId=&{id}&boundaryId=10`,
+        ]}
+      />,
+    );
+    await waitFor(() => screen.getByText("SELECTED LOCATION"));
+    await act(() => fireEvent.click(screen.getByText("Clear")));
+    await waitFor(() =>
+      expect(screen.queryByText("SELECTED LOCATION")).not.toBeInTheDocument(),
+    );
   });
 });

--- a/app/layouts/ResultsPanel.tsx
+++ b/app/layouts/ResultsPanel.tsx
@@ -52,6 +52,7 @@ import { ExportDataModal } from "../components/ExportDataModal";
 import { NoResultsWarning } from "~/components/NoResultsWarning";
 import { env } from "~/utils/env";
 import { LinkBtn } from "~/components/LinkBtn";
+import { SelectedLocations } from "~/components/SelectedLocations";
 
 export const policyAreaIcons: Record<
   number,
@@ -275,6 +276,12 @@ export default function ResultsPanel() {
     hoveredOverItem: string;
     setHoveredOverItem: (newHoveredOverItem: string | null) => void;
   }>();
+
+  const boroughIds = searchParams.get("boroughIds");
+  const showSelections =
+    (boundaryType !== null && boundaryId !== null) ||
+    (boundaryType !== null && boroughIds !== null && boroughIds.length > 0);
+
   return (
     <ContentPanelAccordion
       accordionHeading={
@@ -283,6 +290,7 @@ export default function ResultsPanel() {
           : `${totalProjects + totalBudgetRequests} Results`
       }
     >
+      {showSelections && env.facDbPhase1 === "ON" && <SelectedLocations />}
       <Tabs
         index={tabIndex}
         onChange={handleTabsChange}


### PR DESCRIPTION
#### Description
Added selected location section to results panel for CC, CCD, and Borough selections (behind the FacDB Phase 1 flag)
 - added tag wrappers for selections with x button to clear selection 
 - clear button to clear all selections
 - added tests for new fucntionality
 - fixed failing `Resultspanel` tests. Tests failed due to of copy changes and items removed from the document
<img width="457" height="456" alt="Screenshot 2026-04-15 at 9 24 05 AM" src="https://github.com/user-attachments/assets/45973db2-4d28-4cb0-8f4c-bb3d3fca4533" />


#### Tickets
Closes #412 
