### PR TITLE
438 Filtering behavior on the content panel

### DIFF
--- a/app/components/SearchByAttributeMenu.tsx
+++ b/app/components/SearchByAttributeMenu.tsx
@@ -15,7 +15,10 @@ import {
   CommitmentsTotalMin,
   QueryParams,
 } from "../utils/types";
-import { useUpdateSearchParams } from "~/utils/utils";
+import {
+  useUpdateSearchParams,
+  useDismissWelcomeAndUpdateSearchParams,
+} from "~/utils/utils";
 import { Agency, AgencyBudget } from "~/gen";
 import { env } from "~/utils/env";
 
@@ -25,7 +28,7 @@ export const SearchByAttributeMenu = ({
   onClear,
   updateFiltersAccordion,
 }: SearchByAttributeMenuProps) => {
-  const [searchParams, updateSearchParams] = useUpdateSearchParams();
+  const [searchParams] = useUpdateSearchParams();
   const managingAgency = searchParams.get(
     "managingAgency",
   ) as ManagingAgencyInitials;
@@ -36,6 +39,8 @@ export const SearchByAttributeMenu = ({
   const commitmentsTotalMax = searchParams.get(
     "commitmentsTotalMax",
   ) as CommitmentsTotalMax;
+  const dismissWelcomeAndUpdateSearchParams =
+    useDismissWelcomeAndUpdateSearchParams();
 
   const appliedFilters: number[] = [
     managingAgency !== null ? 1 : 0,
@@ -86,21 +91,28 @@ export const SearchByAttributeMenu = ({
               selectValue={managingAgency}
               agencies={agencies}
               onSelectValueChange={(value) => {
-                updateSearchParams({ managingAgency: value });
+                dismissWelcomeAndUpdateSearchParams("/capital-projects", {
+                  managingAgency: value,
+                });
               }}
             />
             <ProjectTypeDropdown
               selectValue={agencyBudget}
               projectTypes={projectTypes}
               onSelectValueChange={(value) => {
-                updateSearchParams({ agencyBudget: value });
+                dismissWelcomeAndUpdateSearchParams("/capital-projects", {
+                  agencyBudget: value,
+                });
               }}
             />
             <ProjectAmountMenu
               commitmentsTotalMin={commitmentsTotalMin}
               commitmentsTotalMax={commitmentsTotalMax}
               onValidChange={(changes: QueryParams) => {
-                updateSearchParams(changes);
+                dismissWelcomeAndUpdateSearchParams(
+                  "/capital-projects",
+                  changes,
+                );
               }}
             />
           </AccordionPanel>

--- a/app/components/SearchByCbbrMenu.tsx
+++ b/app/components/SearchByCbbrMenu.tsx
@@ -5,7 +5,10 @@ import {
   AccordionPanel,
   Heading,
 } from "@nycplanning/streetscape";
-import { useUpdateSearchParams } from "../utils/utils";
+import {
+  useUpdateSearchParams,
+  useDismissWelcomeAndUpdateSearchParams,
+} from "../utils/utils";
 import {
   Agency,
   CommunityBoardBudgetRequestAgencyCategoryResponse,
@@ -45,7 +48,9 @@ export const SearchByCbbrMenu = ({
   onClear,
   updateFiltersAccordion,
 }: SearchByCbbrMenuProps) => {
-  const [searchParams, updateSearchParams] = useUpdateSearchParams();
+  const [searchParams] = useUpdateSearchParams();
+  const dismissWelcomeAndUpdateSearchParams =
+    useDismissWelcomeAndUpdateSearchParams();
   const cbbrPolicyAreaId = searchParams.get(
     "cbbrPolicyAreaId",
   ) as CommunityBoardBudgetRequestPolicyAreaId;
@@ -115,21 +120,30 @@ export const SearchByCbbrMenu = ({
               selectValue={cbbrPolicyAreaId}
               cbbrPolicyAreas={cbbrPolicyAreas}
               onSelectValueChange={(value) => {
-                updateSearchParams({ cbbrPolicyAreaId: value });
+                dismissWelcomeAndUpdateSearchParams(
+                  "/community-board-budget-requests",
+                  { cbbrPolicyAreaId: value },
+                );
               }}
             />
             <CommunityBoardBudgetRequestNeedGroupDropdown
               selectValue={cbbrNeedGroupId}
               cbbrNeedGroups={cbbrNeedGroups}
               onSelectValueChange={(value) => {
-                updateSearchParams({ cbbrNeedGroupId: value });
+                dismissWelcomeAndUpdateSearchParams(
+                  "/community-board-budget-requests",
+                  { cbbrNeedGroupId: value },
+                );
               }}
             />
             <CommunityBoardBudgetRequestAgencyDropdown
               selectValue={cbbrAgencyInitials}
               cbbrAgencies={cbbrAgencies}
               onSelectValueChange={(value) => {
-                updateSearchParams({ cbbrAgencyInitials: value });
+                dismissWelcomeAndUpdateSearchParams(
+                  "/community-board-budget-requests",
+                  { cbbrAgencyInitials: value },
+                );
               }}
             />
             <CbbrAgencyCategoryResponseCheckbox
@@ -151,10 +165,13 @@ export const SearchByCbbrMenu = ({
                 } else {
                   nextValue = cbbrAgencyCategoryResponseIds.concat([value]);
                 }
-                updateSearchParams({
-                  cbbrAgencyCategoryResponseIds:
-                    nextValue === null ? nextValue : String(nextValue),
-                });
+                dismissWelcomeAndUpdateSearchParams(
+                  "/community-board-budget-requests",
+                  {
+                    cbbrAgencyCategoryResponseIds:
+                      nextValue === null ? nextValue : String(nextValue),
+                  },
+                );
               }}
             />
           </AccordionPanel>

--- a/app/components/layers/useBoroughsLayer.client.tsx
+++ b/app/components/layers/useBoroughsLayer.client.tsx
@@ -2,7 +2,10 @@ import { MVTLayer } from "@deck.gl/geo-layers";
 import { useState } from "react";
 import { env } from "~/utils/env";
 import { BoroughId, BoundaryType } from "~/utils/types";
-import { useUpdateSearchParams } from "~/utils/utils";
+import {
+  useUpdateSearchParams,
+  useDismissWelcomeAndUpdateSearchParams,
+} from "~/utils/utils";
 
 const { zoningApiUrl, facDbPhase1 } = env;
 
@@ -18,6 +21,8 @@ export function useBoroughsLayer({
   clearCombobox: () => void;
 }) {
   const [searchParams, updateSearchParams] = useUpdateSearchParams();
+  const dismissWelcomeAndUpdateSearchParams =
+    useDismissWelcomeAndUpdateSearchParams();
   const [isHovered, setIsHovered] = useState<string | undefined>();
   const boundaryType = searchParams.get("boundaryType") as BoundaryType;
   const boroughIds = searchParams.get("boroughIds") as BoroughId;
@@ -57,7 +62,7 @@ export function useBoroughsLayer({
           });
         } else {
           clearCombobox();
-          updateSearchParams({
+          dismissWelcomeAndUpdateSearchParams("/capital-projects", {
             boroughIds: info.object.properties.id,
             search: undefined,
             radius: undefined,

--- a/app/components/layers/useCityCouncilDistrictsLayer.client.tsx
+++ b/app/components/layers/useCityCouncilDistrictsLayer.client.tsx
@@ -1,6 +1,9 @@
 import { MVTLayer } from "@deck.gl/geo-layers";
 import { useState } from "react";
-import { useUpdateSearchParams } from "~/utils/utils";
+import {
+  useUpdateSearchParams,
+  useDismissWelcomeAndUpdateSearchParams,
+} from "~/utils/utils";
 import { BoundaryId, BoundaryType } from "~/utils/types";
 import { env } from "~/utils/env";
 
@@ -16,6 +19,8 @@ export function useCityCouncilDistrictsLayer({
   clearCombobox: () => void;
 }) {
   const [searchParams, updateSearchParams] = useUpdateSearchParams();
+  const dismissWelcomeAndUpdateSearchParams =
+    useDismissWelcomeAndUpdateSearchParams();
   const [isHovered, setIsHovered] = useState<string | undefined>();
   const boundaryType = searchParams.get("boundaryType") as BoundaryType;
   const boundaryId = searchParams.get("boundaryId") as BoundaryId;
@@ -59,7 +64,7 @@ export function useCityCouncilDistrictsLayer({
           });
         } else {
           clearCombobox();
-          updateSearchParams({
+          dismissWelcomeAndUpdateSearchParams("/capital-projects", {
             boundaryId: info.object.properties.id,
             search: undefined,
             radius: undefined,

--- a/app/components/layers/useCommunityDistrictsLayer.client.tsx
+++ b/app/components/layers/useCommunityDistrictsLayer.client.tsx
@@ -1,6 +1,9 @@
 import { MVTLayer } from "@deck.gl/geo-layers";
 import { useState } from "react";
-import { useUpdateSearchParams } from "~/utils/utils";
+import {
+  useUpdateSearchParams,
+  useDismissWelcomeAndUpdateSearchParams,
+} from "~/utils/utils";
 import { BoroughId, BoundaryId, BoundaryType } from "~/utils/types";
 import { env } from "~/utils/env";
 
@@ -17,6 +20,8 @@ export function useCommunityDistrictsLayer({
   clearCombobox: () => void;
 }) {
   const [searchParams, updateSearchParams] = useUpdateSearchParams();
+  const dismissWelcomeAndUpdateSearchParams =
+    useDismissWelcomeAndUpdateSearchParams();
   const [isHovered, setIsHovered] = useState<string | undefined>();
   const boundaryType = searchParams.get("boundaryType") as BoundaryType;
   const boroughId = searchParams.get("boroughId") as BoroughId;
@@ -84,7 +89,7 @@ export function useCommunityDistrictsLayer({
             });
           } else {
             clearCombobox();
-            updateSearchParams({
+            dismissWelcomeAndUpdateSearchParams("/capital-projects", {
               boundaryType: "cd",
               boroughId: info.object.properties.boroughIdCommunityDistrictId[0],
               boundaryId:

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -1,5 +1,10 @@
 import { compareAsc, format, getMonth, getYear } from "date-fns";
-import { useSearchParams, SetURLSearchParams } from "react-router";
+import {
+  useLocation,
+  useNavigate,
+  useSearchParams,
+  SetURLSearchParams,
+} from "react-router";
 import {
   CommitmentsTotalMin,
   CommitmentsTotalMax,
@@ -181,4 +186,28 @@ export function useUpdateSearchParams(): [
     setSearchParams(setNewSearchParams(searchParams, changes));
   };
   return [searchParams, updateSearchParams, setSearchParams];
+}
+
+export function useDismissWelcomeAndUpdateSearchParams() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const dismissWelcomeAndUpdateSearchParams = (
+    newPath: string,
+    changes: QueryParams,
+  ) => {
+    if (pathname === "/") {
+      const nextSearchParams = setNewSearchParams(searchParams, changes);
+      navigate(
+        {
+          pathname: newPath,
+          search: nextSearchParams.toString(),
+        },
+        { replace: true },
+      );
+    } else {
+      setSearchParams(setNewSearchParams(searchParams, changes));
+    }
+  };
+  return dismissWelcomeAndUpdateSearchParams;
 }


### PR DESCRIPTION
This change removes the welcome panel when a user applies any filter.

When the geography was being selected from a drop-down, it had been done in the [FilterMenu](https://github.com/NYCPlanning/ae-cp-map/blob/25ab8b22e549381c8157ffecf8a59207a49726d7/app/components/FilterMenu.tsx#L34).

Closes #438.