### PR TITLE
Update address search no results message and add error message.

### DIFF
--- a/app/address-search/axios/findAddresses.ts
+++ b/app/address-search/axios/findAddresses.ts
@@ -18,11 +18,11 @@ import { findAddressesQueryResponseSchema } from "../zod";
 export async function findAddresses(
   text: FindAddressesQueryParams["text"],
   config: Partial<RequestConfig> & { client?: typeof fetch } = {},
-) {
+): Promise<FindAddressesQueryResponse> {
   const { client: request = fetch, ...requestConfig } = config;
 
   const res = await request<
-    FindAddressesQueryResponse,
+    unknown,
     ResponseErrorConfig<FindAddresses400 | FindAddresses500>,
     unknown
   >({
@@ -30,11 +30,5 @@ export async function findAddresses(
     url: `https://geosearch.planninglabs.nyc/v2/autocomplete?size=5&text=${text}`,
     ...requestConfig,
   });
-  try {
-    findAddressesQueryResponseSchema.parse(res.data);
-  } catch (e) {
-    console.error("Invalid response", res);
-  }
-
-  return res.data;
+  return await findAddressesQueryResponseSchema.parse(res.data);
 }

--- a/app/components/HeaderBar/AddressSearch.tsx
+++ b/app/components/HeaderBar/AddressSearch.tsx
@@ -24,11 +24,13 @@ export const AddressSearch = ({
   combobox,
   addressSearchQuery,
   addressSearchResults,
+  addressSearchError,
   isLoading,
 }: {
   combobox: UseComboboxReturn;
   addressSearchQuery: string | null;
   addressSearchResults: ListCollection;
+  addressSearchError: Error | null;
   isLoading: boolean;
 }) => {
   return (
@@ -77,14 +79,10 @@ export const AddressSearch = ({
             <Text fontSize={"sm"}>Loading...</Text>
           ) : (
             <VStack padding={4} gap={3} align={"flex-start"}>
-              <Text fontSize={"sm"}>Sorry, no results found.</Text>
-              <Box>
-                <Text fontSize={"sm"}>Suggestions:</Text>
-                <UnorderedList>
-                  <ListItem fontSize={"sm"}>
-                    Check your search for typos.
-                  </ListItem>
-                  <ListItem fontSize={"sm"}>
+              {addressSearchError ? (
+                <>
+                  <Text fontSize={"sm"}>Sorry, something went wrong.</Text>
+                  <Text fontSize={"sm"}>
                     Need help?{" "}
                     <Link
                       color={"primary.600"}
@@ -93,9 +91,31 @@ export const AddressSearch = ({
                     >
                       E-mail us.
                     </Link>
-                  </ListItem>
-                </UnorderedList>
-              </Box>
+                  </Text>
+                </>
+              ) : (
+                <>
+                  <Text fontSize={"sm"}>Sorry, no results found.</Text>
+                  <Box>
+                    <Text fontSize={"sm"}>Suggestions:</Text>
+                    <UnorderedList>
+                      <ListItem fontSize={"sm"}>
+                        Check your search for typos.
+                      </ListItem>
+                      <ListItem fontSize={"sm"}>
+                        Need help?{" "}
+                        <Link
+                          color={"primary.600"}
+                          textDecorationLine={"underline"}
+                          href="mailto:CAPS@planning.nyc.gov"
+                        >
+                          E-mail us.
+                        </Link>
+                      </ListItem>
+                    </UnorderedList>
+                  </Box>
+                </>
+              )}
             </VStack>
           )}
         </Combobox.Content>

--- a/app/components/HeaderBar/AddressSearch.tsx
+++ b/app/components/HeaderBar/AddressSearch.tsx
@@ -1,4 +1,13 @@
-import { Combobox, MapPinIcon, Text } from "@nycplanning/streetscape";
+import {
+  Combobox,
+  MapPinIcon,
+  Text,
+  VStack,
+  UnorderedList,
+  ListItem,
+  Link,
+  Box,
+} from "@nycplanning/streetscape";
 import { SearchIcon, CloseIcon } from "@chakra-ui/icons";
 import type {
   ListCollection,
@@ -50,7 +59,7 @@ export const AddressSearch = ({
           }
         >
           <Text
-            paddingTop={2}
+            paddingY={2}
             fontSize={"sm"}
             fontWeight={"700"}
             color={"gray.700"}
@@ -65,9 +74,29 @@ export const AddressSearch = ({
               </Combobox.Item>
             ))
           ) : isLoading && addressSearchQuery !== null ? (
-            <Text fontSize={"xs"}>Loading...</Text>
+            <Text fontSize={"sm"}>Loading...</Text>
           ) : (
-            <Text fontSize={"xs"}>No results found.</Text>
+            <VStack padding={4} gap={3} align={"flex-start"}>
+              <Text fontSize={"sm"}>Sorry, no results found.</Text>
+              <Box>
+                <Text fontSize={"sm"}>Suggestions:</Text>
+                <UnorderedList>
+                  <ListItem fontSize={"sm"}>
+                    Check your search for typos.
+                  </ListItem>
+                  <ListItem fontSize={"sm"}>
+                    Need help?{" "}
+                    <Link
+                      color={"primary.600"}
+                      textDecorationLine={"underline"}
+                      href="mailto:CAPS@planning.nyc.gov"
+                    >
+                      E-mail us.
+                    </Link>
+                  </ListItem>
+                </UnorderedList>
+              </Box>
+            </VStack>
           )}
         </Combobox.Content>
       </Combobox.Positioner>

--- a/app/components/HeaderBar/HeaderBar.test.tsx
+++ b/app/components/HeaderBar/HeaderBar.test.tsx
@@ -33,6 +33,7 @@ describe("Header Bar", () => {
           {...defaultRadiusProps}
           addressSearchQuery={null}
           addressSearchResults={collection}
+          addressSearchError={null}
           isLoading={false}
           combobox={combobox}
         />
@@ -64,6 +65,7 @@ describe("Header Bar", () => {
           clearSelections={clearSelections}
           addressSearchQuery={null}
           addressSearchResults={collection}
+          addressSearchError={null}
           isLoading={false}
           combobox={combobox}
         />
@@ -94,6 +96,7 @@ describe("Header Bar", () => {
           {...defaultRadiusProps}
           addressSearchQuery={null}
           addressSearchResults={collection}
+          addressSearchError={null}
           isLoading={false}
           combobox={combobox}
         />

--- a/app/components/HeaderBar/HeaderBar.tsx
+++ b/app/components/HeaderBar/HeaderBar.tsx
@@ -13,6 +13,7 @@ export function HeaderBar({
   combobox,
   addressSearchQuery,
   addressSearchResults,
+  addressSearchError,
   isLoading,
   addressSearchSliderValue,
   setAddressSearchSliderValue,
@@ -22,6 +23,7 @@ export function HeaderBar({
   combobox: UseComboboxReturn;
   addressSearchQuery: string | null;
   addressSearchResults: ListCollection;
+  addressSearchError: Error | null;
   isLoading: boolean;
   addressSearchSliderValue: number | undefined;
   setAddressSearchSliderValue: (v: number | undefined) => void | undefined;
@@ -117,6 +119,7 @@ export function HeaderBar({
                 combobox={combobox}
                 addressSearchQuery={addressSearchQuery}
                 addressSearchResults={addressSearchResults}
+                addressSearchError={addressSearchError}
                 isLoading={isLoading}
                 aria-label="address search dropdown"
               />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -109,7 +109,11 @@ export function Main() {
       ? findAddresses(addressSearchQuery)
       : null;
   };
-  const { data: addressSearchResults, isLoading } = useQuery({
+  const {
+    data: addressSearchResults,
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ["find-addresses", addressSearchQuery],
     queryFn: queryFunction,
   });
@@ -215,6 +219,7 @@ export function Main() {
         combobox={combobox}
         addressSearchQuery={addressSearchQuery}
         addressSearchResults={collection}
+        addressSearchError={error}
         isLoading={isLoading}
         addressSearchSliderValue={addressSearchSliderValue}
         setAddressSearchSliderValue={setAddressSearchSliderValue}


### PR DESCRIPTION
Closes #431 

### Summary

Updates the message shown to users when their address search returns no result
<img width="490" height="270" alt="image" src="https://github.com/user-attachments/assets/77fa0d7a-4103-442a-b3e6-dc47145d7167" />


Adds a new error message shown to users when their address search fails for some reason. This can be tested by blocking requests to geosearch in dev tools. **Note you will still see "loading" for a couple seconds because Tanstack query defaults to retrying queries 3 times.** This error will also be shown if the network request to Geosearch is successful but the Zod `.parse` fails for some reason.
<img width="415" height="209" alt="image" src="https://github.com/user-attachments/assets/258bcb73-2c55-499c-8bbe-2a545e6a0074" />
