### PR TITLE
481 [Bug]: Welcome message flashes and disappears

### DIFF
--- a/app/components/SearchByAttributeMenu.tsx
+++ b/app/components/SearchByAttributeMenu.tsx
@@ -108,10 +108,14 @@ export const SearchByAttributeMenu = ({
               commitmentsTotalMin={commitmentsTotalMin}
               commitmentsTotalMax={commitmentsTotalMax}
               onValidChange={(changes: QueryParams) => {
-                dismissWelcomeAndUpdateSearchParams(
-                  "/capital-projects",
-                  changes,
-                );
+                if (
+                  changes.commitmentsTotalMin !== null ||
+                  changes.commitmentsTotalMax !== null
+                )
+                  dismissWelcomeAndUpdateSearchParams(
+                    "/capital-projects",
+                    changes,
+                  );
               }}
             />
           </AccordionPanel>


### PR DESCRIPTION
Prevented ProjectAmountMenu's `onValidChange` from automatically dismissing the welcome message upon page load.

Closes #481