### PR TITLE
there is some sort of bug in the pagination page counts

### DIFF
--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -28,9 +28,9 @@ export const Pagination = ({ total, pageParamKey, label }: PaginationProps) => {
   const totalPages = Math.ceil(total / itemsPerPage);
   const canSkipForward = page < totalPages;
 
-  const firstItem = total === 0 ? 0 : (page - 1) * itemsPerPage + 1;
+  const firstItem = (page - 1) * itemsPerPage + 1;
 
-  const lastItem = total === 0 ? 0 : Math.min(page * itemsPerPage, total);
+  const lastItem = Math.min(page * itemsPerPage, total);
 
   const navigation = useNavigation();
   const isNavigating = Boolean(navigation.location);
@@ -78,12 +78,7 @@ export const Pagination = ({ total, pageParamKey, label }: PaginationProps) => {
             paddingTop={1}
           >
             {"Page "}
-            {totalPages === 0
-              ? 0
-              : isNavigating
-                ? page + pageLoaderIncrement
-                : page}{" "}
-            of {totalPages}
+            {isNavigating ? page + pageLoaderIncrement : page} of {totalPages}
           </Text>
         </Skeleton>
         <Link


### PR DESCRIPTION
#### This is only a pair programming exercise. Never, ever merge this.

### What happened? What did you expect to happen?

_**Repro steps:**_

1. Make sure "Community Board Capital Budget Requests" toggle is turned on 
2. Select an address in the input box
3. Make a selections from the FIlters section
4. Apply a Radius Filter

[Link to selection](http://localhost:5173/capital-projects?search=32453+SPRINGFIELD+BOULEVARD%2C+Queens&pin=-73.742314%2C40.69866&cbbrPolicyAreaId=1&cbbrNeedGroupId=3&cbbrAgencyInitials=DHS&radius=400)

_**Expected:**_
I would expect both counters to read: `0 of 0`
 
_**Actual:**_ 
Result and Page Number counters both read: `1 of 0`
<img width="1909" height="951" alt="Screenshot 2026-06-12 at 3 50 11 PM" src="https://github.com/user-attachments/assets/1b32bcda-e608-4c83-b6f4-5f7217bec676" />

