### PR TITLE
Add Facility Oversight Agency Dropdown

### DIFF
--- a/app/components/DropdownControl/AgencyDropdown.tsx
+++ b/app/components/DropdownControl/AgencyDropdown.tsx
@@ -1,5 +1,4 @@
-// import { Agency } from "/gen";
-import { Agency } from "../../gen"; // remove this and uncomment line 1 before merging
+import { Agency } from "../../gen";
 import { DropdownControlProps, DropdownControl } from ".";
 import { ManagingAgencyInitials } from "../../utils/types";
 

--- a/app/components/DropdownControl/OverightAgencyDropdown.test.tsx
+++ b/app/components/DropdownControl/OverightAgencyDropdown.test.tsx
@@ -1,0 +1,56 @@
+import { Agency, createAgency } from "../../gen";
+import { OversightAgencyDropdown } from "./OverightAgencyDropdown";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { act } from "react";
+
+describe("OversightAgencyDropdown", () => {
+  let agencies: Array<Agency> = [];
+
+  beforeAll(() => {
+    agencies = Array.from(Array(1), () => createAgency());
+  });
+
+  it("should render oversight agency form details and options", () => {
+    const onSelectValueChange = vi.fn();
+
+    render(
+      <OversightAgencyDropdown
+        onSelectValueChange={onSelectValueChange}
+        agencies={agencies}
+      />,
+    );
+
+    expect(screen.getByLabelText("Oversight Agency")).toBeInTheDocument();
+
+    const firstAgencyLabel = `${agencies[0].name} (${agencies[0].initials})`;
+    expect(screen.getByText(firstAgencyLabel)).toBeInTheDocument();
+  });
+
+  it("should set search params when changing the oversight agency", async () => {
+    const onSelectValueChange = vi.fn();
+    const firstAgencyInitials = agencies[0].initials;
+
+    render(
+      <OversightAgencyDropdown
+        onSelectValueChange={onSelectValueChange}
+        agencies={agencies}
+      />,
+    );
+
+    await act(() =>
+      userEvent.selectOptions(
+        screen.getByRole("combobox"),
+        firstAgencyInitials,
+      ),
+    );
+
+    expect(onSelectValueChange).toHaveBeenCalledWith(firstAgencyInitials);
+  });
+
+  it("should disable the dropdown when agencies are null", () => {
+    render(<OversightAgencyDropdown agencies={null} />);
+
+    expect(screen.getByLabelText("Oversight Agency")).toBeDisabled();
+  });
+});

--- a/app/components/DropdownControl/OverightAgencyDropdown.tsx
+++ b/app/components/DropdownControl/OverightAgencyDropdown.tsx
@@ -1,0 +1,42 @@
+import { Agency } from "../../gen";
+import { DropdownControl, DropdownControlProps } from ".";
+import { FacilityOversightAgency } from "../../utils/types";
+
+export interface OversightAgencyDropdownProps
+  extends Pick<DropdownControlProps, "selectValue"> {
+  agencies: Agency[] | null;
+  onSelectValueChange?: (value: FacilityOversightAgency) => void;
+}
+
+export function OversightAgencyDropdown({
+  selectValue,
+  agencies,
+  onSelectValueChange = () => null,
+}: OversightAgencyDropdownProps) {
+  const updateFacilityAgency = (
+    nextFacilityAgency: FacilityOversightAgency,
+  ) => {
+    onSelectValueChange(nextFacilityAgency);
+  };
+
+  const agencyOptions = agencies?.map((agency) => (
+    <option key={agency.initials} value={agency.initials}>
+      {agency.name} ({agency.initials})
+    </option>
+  ));
+
+  return (
+    <DropdownControl
+      formId="facilityOversightAgency"
+      formLabel="Oversight Agency"
+      isSelectDisabled={agencies === null}
+      selectValue={selectValue}
+      onSelectValueChange={updateFacilityAgency}
+      fontWeight="700"
+      placeholder="All agencies"
+      marginBottom={4}
+    >
+      {agencyOptions}
+    </DropdownControl>
+  );
+}

--- a/app/components/DropdownControl/index.tsx
+++ b/app/components/DropdownControl/index.tsx
@@ -4,3 +4,4 @@ export { ProjectTypeDropdown } from "./ProjectTypeDropdown";
 export { CommunityBoardBudgetRequestAgencyDropdown } from "./CommunityBoardBudgetRequestAgencyDropdown";
 export { CommunityBoardBudgetRequestNeedGroupDropdown } from "./CommunityBoardBudgetRequestNeedGroupDropdown";
 export { CommunityBoardBudgetRequestPolicyAreaDropdown } from "./CommunityBoardBudgetRequestPolicyAreaDropdown";
+export { OversightAgencyDropdown } from "./OverightAgencyDropdown";

--- a/app/components/MapLayerToggle/index.tsx
+++ b/app/components/MapLayerToggle/index.tsx
@@ -1,3 +1,4 @@
 export * from "./MapLayerToggle";
 export * from "./CapitalProjectLayerToggle";
 export * from "./CommunityBoardBudgetRequestLayerToggle";
+export * from "./FacilitiesLayerToggle";

--- a/app/components/SearchByFacilityMenu.tsx
+++ b/app/components/SearchByFacilityMenu.tsx
@@ -6,19 +6,29 @@ import {
   Heading,
 } from "@nycplanning/streetscape";
 import { useDismissWelcomeAndUpdateSearchParams } from "../utils/utils";
-import { FacilityType, FacilityTypes } from "../utils/types";
+import {
+  FacilityOversightAgency,
+  FacilityType,
+  FacilityTypes,
+} from "../utils/types";
 import { ClearFilterBtn } from "./ClearFilter";
 import { FacilityTypeCheckbox } from "./CheckboxControl";
+import { OversightAgencyDropdown } from "./DropdownControl";
 import { useStore } from "~/store";
+import { Agency } from "~/gen";
 
 export interface SearchByFacilityMenuProps {
   onClear: () => void;
   updateFiltersAccordion: () => void;
+  facilityAgencies: Array<Agency> | null;
+  facilityOversightAgency: FacilityOversightAgency;
 }
 
 export const SearchByFacilityMenu = ({
   onClear,
   updateFiltersAccordion,
+  facilityAgencies,
+  facilityOversightAgency,
 }: SearchByFacilityMenuProps) => {
   const dismissWelcomeAndUpdateSearchParams =
     useDismissWelcomeAndUpdateSearchParams();
@@ -34,6 +44,7 @@ export const SearchByFacilityMenu = ({
     facilityTypeIds !== null && facilityTypeIds.length < 3
       ? facilityTypeIds.length
       : 0,
+    facilityOversightAgency !== null ? 1 : 0,
   ];
 
   return (
@@ -97,6 +108,15 @@ export const SearchByFacilityMenu = ({
           dismissWelcomeAndUpdateSearchParams={
             dismissWelcomeAndUpdateSearchParams
           }
+        />
+        <OversightAgencyDropdown
+          agencies={facilityAgencies}
+          selectValue={facilityOversightAgency}
+          onSelectValueChange={(value) => {
+            dismissWelcomeAndUpdateSearchParams("/facilities", {
+              facilityOversightAgency: value,
+            });
+          }}
         />
       </AccordionPanel>
     </AccordionItem>

--- a/app/components/Skeletons/FacilityListItemSkeleton.tsx
+++ b/app/components/Skeletons/FacilityListItemSkeleton.tsx
@@ -8,25 +8,25 @@ import {
 } from "@nycplanning/streetscape";
 
 export function FacilityListItemSkeleton() {
-    return (
-        <Card
-            variant={"calm"}
-            direction={"row"}
-            width={"100%"}
-            justifyContent={"space-between"}
-        >
-            <Flex direction={"row"}>
-                <Skeleton height={2} width={2} borderRadius={"35px"}>
-                    <Icon boxSize={2} />
-                </Skeleton>
-                <CardBody marginLeft={5} marginRight={6}>
-                    <Skeleton maxH={5} minW={"100%"}>
-                        <Heading fontSize={"sm"} fontWeight={"bold"}>
-                            Sample Facility Name
-                        </Heading>
-                    </Skeleton>
-                </CardBody>
-            </Flex>
-        </Card>
-    );
+  return (
+    <Card
+      variant={"calm"}
+      direction={"row"}
+      width={"100%"}
+      justifyContent={"space-between"}
+    >
+      <Flex direction={"row"}>
+        <Skeleton height={2} width={2} borderRadius={"35px"}>
+          <Icon boxSize={2} />
+        </Skeleton>
+        <CardBody marginLeft={5} marginRight={6}>
+          <Skeleton maxH={5} minW={"100%"}>
+            <Heading fontSize={"sm"} fontWeight={"bold"}>
+              Sample Facility Name
+            </Heading>
+          </Skeleton>
+        </CardBody>
+      </Flex>
+    </Card>
+  );
 }

--- a/app/components/layers/useFacilitiesLayer.client.tsx
+++ b/app/components/layers/useFacilitiesLayer.client.tsx
@@ -74,6 +74,8 @@ export function useFacilitiesLayer({
       ? [undefined, undefined]
       : pin.split(",").map((d) => parseFloat(d));
 
+  const facilityOversightAgency = searchParams.get("facilityOversightAgency");
+
   const facilityTypeCheckboxes = useStore(
     (state) => state.facilityTypeCheckboxes,
   );
@@ -96,6 +98,11 @@ export function useFacilitiesLayer({
       }
     },
     getIconSize: ({ properties }: { properties: FacilityProperties }) => {
+      if (
+        facilityOversightAgency !== null &&
+        properties.overseeingAgencyInitials !== facilityOversightAgency
+      )
+        return 0;
       if (
         properties.facilityOperatorType === undefined &&
         !facilityTypeIds.includes("Not specified")
@@ -138,7 +145,7 @@ export function useFacilitiesLayer({
     updateTriggers: {
       getIcon: [facilityId, hoveredFacility],
       onHover: hoveredFacility,
-      getIconSize: [facilityTypeIds],
+      getIconSize: [facilityTypeIds, facilityOversightAgency],
     },
     extensions: [new MaskExtension()],
     maskId: `${

--- a/app/layouts/MapPage.tsx
+++ b/app/layouts/MapPage.tsx
@@ -25,6 +25,7 @@ import { Atlas, MAX_ZOOM, MIN_ZOOM } from "../components/atlas.client";
 import {
   findBoroughs,
   findCityCouncilDistricts,
+  findFacilityAgencies,
   findCommunityDistrictsByBoroughId,
   findAgencyBudgets,
   findCapitalProjectManagingAgencies,
@@ -49,16 +50,16 @@ import { HowToUseThisTool } from "../components/AdminDropdownContent/HowToUseThi
 import {
   CapitalProjectLayerToggle,
   CommunityBoardBudgetRequestLayerToggle,
+  FacilitiesLayerToggle,
 } from "~/components/MapLayerToggle";
 import { CommunityBoardBudgetRequestLegend } from "../components/CommunityBoardBudgetRequestLegend";
 import { useUpdateSearchParams } from "../utils/utils";
 import type { RootContextType } from "../root";
 import { MapViewControls } from "~/components/MapViewControls";
 import { SearchByCbbrMenu } from "~/components/SearchByCbbrMenu";
+import { SearchByFacilityMenu } from "~/components/SearchByFacilityMenu";
 import { useState, useEffect } from "react";
 import { useStore } from "~/store";
-import { FacilitiesLayerToggle } from "~/components/MapLayerToggle/FacilitiesLayerToggle";
-import { SearchByFacilityMenu } from "~/components/SearchByFacilityMenu";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
@@ -84,11 +85,19 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       ? []
       : (facilityTypesParam.split(",") as FacilityType[]);
 
+  const facilityOversightAgency = url.searchParams.get(
+    "facilityOversightAgency",
+  );
+
   const { managingAgencies } = await findCapitalProjectManagingAgencies({
     baseURL: `${env.zoningApiUrl}/api`,
   });
 
   const { agencyBudgets } = await findAgencyBudgets({
+    baseURL: `${env.zoningApiUrl}/api`,
+  });
+
+  const facilityAgencies = await findFacilityAgencies({
     baseURL: `${env.zoningApiUrl}/api`,
   });
 
@@ -151,6 +160,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         cbbrAgencyCategoryResponses,
         cbbrAgencyCategoryResponseIds,
         facilityTypes,
+        facilityOversightAgency,
+        facilityAgencies,
       };
     } else {
       const { communityDistricts } = await findCommunityDistrictsByBoroughId(
@@ -172,6 +183,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         cbbrAgencyCategoryResponses,
         cbbrAgencyCategoryResponseIds,
         facilityTypes,
+        facilityOversightAgency,
+        facilityAgencies,
       };
     }
   }
@@ -192,6 +205,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       cbbrAgencyCategoryResponses,
       cbbrAgencyCategoryResponseIds,
       facilityTypes,
+      facilityOversightAgency,
+      facilityAgencies,
     };
   }
 
@@ -207,6 +222,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     cbbrAgencyCategoryResponses,
     cbbrAgencyCategoryResponseIds,
     facilityTypes,
+    facilityOversightAgency,
+    facilityAgencies,
   };
 };
 
@@ -246,6 +263,8 @@ export default function MapPage() {
     cbbrAgencyCategoryResponses,
     cbbrAgencyCategoryResponseIds,
     facilityTypes,
+    facilityOversightAgency,
+    facilityAgencies,
   } = useLoaderData<typeof loader>();
 
   const initializeCbbrAgencyCategoryResponseCheckboxes = useStore(
@@ -309,6 +328,7 @@ export default function MapPage() {
     });
     updateSearchParams({
       facilityTypes: null,
+      facilityOversightAgency: null,
     });
   }; // This isn't resetting the checkboxes
 
@@ -603,7 +623,9 @@ export default function MapPage() {
                             color={"primary.600"}
                             textDecor={"underline"}
                             cursor={"pointer"}
-                            onClick={() => setFiltersAccordionIndex([0, 1, 2])}
+                            onClick={() =>
+                              setFiltersAccordionIndex([0, 1, 2, 3])
+                            }
                           >
                             Expand All
                           </Link>
@@ -632,6 +654,7 @@ export default function MapPage() {
                               cbbrAgencyInitials: null,
                               cbbrAgencyCategoryResponseIds: null,
                               facilityTypes: null,
+                              facilityOversightAgency: null,
                             });
                             updateAllCbbrAgencyCategoryResponseCheckboxesByValue(
                               true,
@@ -679,6 +702,8 @@ export default function MapPage() {
                         <SearchByFacilityMenu
                           onClear={clearFacilityFilters}
                           updateFiltersAccordion={updateFiltersAccordion(3)}
+                          facilityAgencies={facilityAgencies}
+                          facilityOversightAgency={facilityOversightAgency}
                         />
                       </Box>
                     </Box>

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -17,6 +17,7 @@ export type CommunityBoardBudgetRequestAgencyInitials = string | null;
 export type CommunityBoardBudgetRequestAgencyCategoryResponseId = string | null;
 export type FacilityType = "Public" | "Non-public" | "Not specified";
 export type FacilityTypes = FacilityType[] | null;
+export type FacilityOversightAgency = null | string;
 
 export type AdminQueryParams = {
   boundaryType?: BoundaryType;
@@ -37,6 +38,7 @@ export type AttributeParams = {
   cbbrAgencyInitials?: CommunityBoardBudgetRequestAgencyInitials;
   cbbrAgencyCategoryResponseIds?: CommunityBoardBudgetRequestAgencyCategoryResponseId;
   facilityTypes?: FacilityTypes;
+  facilityOversightAgency?: FacilityOversightAgency;
 };
 
 export type AttributeQueryParams = {


### PR DESCRIPTION
#### Description
 - Add oversight agency dropdown component and test
 - add oversight agency dropdown component to SearchByFacilityMenu
 - update MapPage to include FacilityAgency
 - update types to include facility agency
 - typecheck/lint fixes
  - facility oversight agency wired up to results panel
  - wired facility oversight agency to useFacilitiesLayer to filter map results


#### Tickets
Closes #503 