### PR TITLE
530 Update default visible layers

### DIFF
--- a/app/components/MapLayerToggle/CapitalProjectLayerToggle.tsx
+++ b/app/components/MapLayerToggle/CapitalProjectLayerToggle.tsx
@@ -1,13 +1,24 @@
-import { useUpdateSearchParams } from "~/utils/utils";
+import {
+  getMapLayers,
+  getNewMapLayerQueryParams,
+  useUpdateSearchParams,
+} from "~/utils/utils";
 import { MapLayerToggle } from ".";
 
 export function CapitalProjectLayerToggle() {
   const [searchParams, updateSearchParams] = useUpdateSearchParams();
 
-  const capitalProjectsOn = searchParams.get("capitalProjects") !== "off";
+  const layersParam = searchParams.get("layers");
+  const layers = getMapLayers(layersParam);
+  const capitalProjectsOn = layers.includes("capitalProjects");
 
-  const setCapitalProjects = (next: boolean) =>
-    updateSearchParams({ capitalProjects: next ? undefined : "off" });
+  const toggleCapitalProjects = () => {
+    const newLayers = getNewMapLayerQueryParams({
+      toggledLayer: "capitalProjects",
+      currentLayersParam: layersParam,
+    });
+    updateSearchParams({ layers: newLayers });
+  };
 
   const capitalProjectsTooltipCopy = `New York City’s potential, planned, and ongoing capital projects.
   Unmapped projects, such as the purchase of vehicles or digital infrastructure, are not included in this tool.
@@ -18,7 +29,7 @@ export function CapitalProjectLayerToggle() {
       id="capital-projects-toggle"
       label="Capital Projects"
       isChecked={capitalProjectsOn}
-      onChange={(e) => setCapitalProjects(e.target.checked)}
+      onChange={toggleCapitalProjects}
       tooltipLabel={capitalProjectsTooltipCopy}
       legendIcon="capital-projects"
     />

--- a/app/components/MapLayerToggle/CommunityBoardBudgetRequestLayerToggle.tsx
+++ b/app/components/MapLayerToggle/CommunityBoardBudgetRequestLayerToggle.tsx
@@ -1,15 +1,27 @@
-import { useUpdateSearchParams } from "~/utils/utils";
+import {
+  getMapLayers,
+  getNewMapLayerQueryParams,
+  useUpdateSearchParams,
+} from "~/utils/utils";
 import { MapLayerToggle } from ".";
 
 export function CommunityBoardBudgetRequestLayerToggle() {
   const [searchParams, updateSearchParams] = useUpdateSearchParams();
 
-  const cbbrOn = searchParams.get("cbbr") !== "off";
+  const layersParam = searchParams.get("layers");
+  const layers = getMapLayers(layersParam);
 
-  const setCbbr = (next: boolean) =>
-    updateSearchParams({ cbbr: next ? undefined : "off" });
+  const cbbrOn = layers.includes("cbbr");
 
-  const capitalProjectsBudgetTooltipCopy = `Every year, boards submit prioritized capital budget requests that address local needs.
+  const toggleCbbr = () => {
+    const newLayers = getNewMapLayerQueryParams({
+      toggledLayer: "cbbr",
+      currentLayersParam: layersParam,
+    });
+    updateSearchParams({ layers: newLayers });
+  };
+
+  const cbbrTooltipCopy = `Every year, boards submit prioritized capital budget requests that address local needs.
     Expense requests are not included in this tool. All capital budget requests, mapped and unmapped, are included.
    `;
 
@@ -18,8 +30,8 @@ export function CommunityBoardBudgetRequestLayerToggle() {
       id="cb-capital-budget-requests"
       label="Community Board Capital Budget Requests"
       isChecked={cbbrOn}
-      onChange={(e) => setCbbr(e.target.checked)}
-      tooltipLabel={capitalProjectsBudgetTooltipCopy}
+      onChange={toggleCbbr}
+      tooltipLabel={cbbrTooltipCopy}
       legendIcon="cbbrs"
     />
   );

--- a/app/components/MapLayerToggle/FacilitiesLayerToggle.tsx
+++ b/app/components/MapLayerToggle/FacilitiesLayerToggle.tsx
@@ -1,13 +1,24 @@
-import { useUpdateSearchParams } from "~/utils/utils";
+import {
+  getMapLayers,
+  getNewMapLayerQueryParams,
+  useUpdateSearchParams,
+} from "~/utils/utils";
 import { MapLayerToggle } from ".";
 
 export function FacilitiesLayerToggle() {
   const [searchParams, updateSearchParams] = useUpdateSearchParams();
 
-  const facilitiesOn = searchParams.get("facilities") !== "off";
+  const layersParam = searchParams.get("layers");
+  const layers = getMapLayers(layersParam);
+  const facilitiesOn = layers.includes("facilities");
 
-  const setFacilities = (next: boolean) =>
-    updateSearchParams({ facilities: next ? undefined : "off" });
+  const toggleFacilities = () => {
+    const newLayers = getNewMapLayerQueryParams({
+      toggledLayer: "facilities",
+      currentLayersParam: layersParam,
+    });
+    updateSearchParams({ layers: newLayers });
+  };
 
   const tooltipCopy = `Facilities and programs owned, operated, funded, licensed, or certified by a City, State, or Federal agency.`;
 
@@ -16,7 +27,7 @@ export function FacilitiesLayerToggle() {
       id="facilities"
       label="Facilities"
       isChecked={facilitiesOn}
-      onChange={(e) => setFacilities(e.target.checked)}
+      onChange={toggleFacilities}
       tooltipLabel={tooltipCopy}
       legendIcon="facilities"
     />

--- a/app/layouts/MapPage.tsx
+++ b/app/layouts/MapPage.tsx
@@ -54,7 +54,7 @@ import {
   FacilitiesLayerToggle,
 } from "~/components/MapLayerToggle";
 import { CommunityBoardBudgetRequestLegend } from "../components/CommunityBoardBudgetRequestLegend";
-import { useUpdateSearchParams } from "../utils/utils";
+import { getMapLayers, useUpdateSearchParams } from "../utils/utils";
 import type { RootContextType } from "../root";
 import { MapViewControls } from "~/components/MapViewControls";
 import { SearchByCbbrMenu } from "~/components/SearchByCbbrMenu";
@@ -283,9 +283,7 @@ export default function MapPage() {
     clearRadiusFilter,
   } = useOutletContext<RootContextType>();
   const [searchParams, updateSearchParams] = useUpdateSearchParams();
-  const showCapitalProjects = searchParams.get("capitalProjects") !== "off";
-  const showCbbr = searchParams.get("cbbr") !== "off";
-  const showFacilities = searchParams.get("facilities") !== "off";
+
   const [hoveredOverItem, setHoveredOverItem] = useState<string | null>(null);
   const [filtersAccordionIndex, setFiltersAccordionIndex] = useState<number[]>(
     [],
@@ -411,6 +409,11 @@ export default function MapPage() {
       facilitySubgroupIds: null,
     });
   };
+
+  const layers = getMapLayers(searchParams.get("layers"));
+  const showCapitalProjects = layers.includes("capitalProjects");
+  const showCbbr = layers.includes("cbbr");
+  const showFacilities = layers.includes("facilities");
 
   const boundaryType = searchParams.get("boundaryType") as BoundaryType;
   const boundaryId = searchParams.get("boundaryId") as BoundaryId;

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -78,6 +78,12 @@ export type AddressQueryParams = {
 
 export type LayerParamKey = "capitalProjects" | "cbbr" | "facilities";
 
+export type LayersParam = LayerParamKey[] | [""] | null;
+
+export type LayersQueryParams = {
+  layers?: LayersParam;
+};
+
 export type LayerParamValue = "off" | undefined;
 
 export type LayerQueryParams = Partial<Record<LayerParamKey, LayerParamValue>>;
@@ -87,6 +93,7 @@ export type QueryParams = Partial<
     AttributeParams &
     PaginationQueryParams &
     LayerQueryParams &
+    LayersQueryParams &
     AddressQueryParams
 >;
 

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -13,6 +13,7 @@ import {
   CommitmentsTotalMinSelectValue,
   CommitmentsTotalMaxSelectValue,
   QueryParams,
+  LayerParamKey,
 } from "./types";
 
 export const formatDistance = (distance: number) => {
@@ -228,4 +229,27 @@ export function useDismissWelcomeAndUpdateSearchParams() {
     }
   };
   return dismissWelcomeAndUpdateSearchParams;
+}
+
+export function getMapLayers(layerParams: string | null) {
+  if (layerParams === null) return ["capitalProjects"] as LayerParamKey[];
+  if (layerParams === "") return [] as LayerParamKey[];
+  return layerParams.split(",") as LayerParamKey[];
+}
+
+export function getNewMapLayerQueryParams({
+  toggledLayer,
+  currentLayersParam,
+}: {
+  toggledLayer: LayerParamKey;
+  currentLayersParam: string | null;
+}) {
+  const oldLayers: LayerParamKey[] = getMapLayers(currentLayersParam);
+  let newLayers: LayerParamKey[];
+  if (oldLayers.includes(toggledLayer)) {
+    newLayers = oldLayers.filter((layer) => layer !== toggledLayer);
+  } else {
+    newLayers = [...oldLayers, toggledLayer];
+  }
+  return newLayers.join(",") === "capitalProjects" ? null : newLayers;
 }


### PR DESCRIPTION
This PR moves layers to a single query parameter array, and sets only Capital Projects on by default.


Closes #530 