### PR TITLE
Bug/428 panel styling at sm md breakpoints

### DIFF
--- a/app/components/ContentPanelAccordion/index.tsx
+++ b/app/components/ContentPanelAccordion/index.tsx
@@ -7,6 +7,7 @@ import {
   AccordionIcon,
   useMediaQuery,
 } from "@nycplanning/streetscape";
+import { useOutletContext } from "react-router";
 
 export function ContentPanelAccordion({
   children,
@@ -17,16 +18,25 @@ export function ContentPanelAccordion({
 }) {
   const iconShouldFlip = useMediaQuery("(max-width: 767px)")[0];
 
+  const { isPanelOpen, setIsPanelOpen } = useOutletContext<{
+    isPanelOpen: boolean;
+    setIsPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  }>();
+
   return (
     <Accordion
       width={"100%"}
       maxHeight={"100%"}
-      defaultIndex={[0]}
+      index={isPanelOpen ? 0 : -1}
       allowToggle
       overflowY={"scroll"}
       sx={{ scrollbarWidth: "none" }}
+      onChange={(nextIndex) => {
+        setIsPanelOpen(nextIndex === 0);
+      }}
+      className={"resultsContainer"}
     >
-      <AccordionItem border={"none"}>
+      <AccordionItem border="none">
         {({ isExpanded }) => (
           <>
             <AccordionButton aria-label="Toggle project list panel" p={0}>
@@ -39,6 +49,7 @@ export function ContentPanelAccordion({
               >
                 {accordionHeading}
               </Heading>
+
               {iconShouldFlip ? (
                 <AccordionIcon
                   transform={isExpanded ? "rotate(0deg)" : "rotate(180deg)"}
@@ -47,6 +58,7 @@ export function ContentPanelAccordion({
                 <AccordionIcon />
               )}
             </AccordionButton>
+
             <AccordionPanel
               padding={"0px"}
               overflowY={"hidden"}

--- a/app/components/HeaderBar/HeaderBar.tsx
+++ b/app/components/HeaderBar/HeaderBar.tsx
@@ -40,7 +40,7 @@ export function HeaderBar({
       gridTemplateColumns={"subgrid"}
       alignItems={"center"}
       gridTemplateRows={{
-        base: env.facDbPhase2 === "ON" ? "1fr 1fr" : "1fr",
+        base: env.facDbPhase2 === "ON" ? "1fr 1fr 1dvh" : "1fr",
         lg: "1fr",
       }}
       zIndex={"1000"}
@@ -55,6 +55,7 @@ export function HeaderBar({
       boxShadow={"0 2px 8px 0 rgba(0, 0, 0, 0.16)"}
       position={"sticky"}
       top={0}
+      className={"headerContainer"}
     >
       <GridItem
         gridColumn={{

--- a/app/components/WelcomePanel/WelcomePanel.tsx
+++ b/app/components/WelcomePanel/WelcomePanel.tsx
@@ -1,15 +1,33 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Accordion,
   AccordionButton,
   AccordionIcon,
   AccordionItem,
   AccordionPanel,
+  useBreakpointValue,
 } from "@nycplanning/streetscape";
 import { WelcomeContent, WelcomeHeader } from ".";
 import { isWelcomeHidden, WelcomeGetStarted } from "./WelcomeGetStarted";
+import { useOutletContext } from "react-router";
 
 export function WelcomePanel() {
+  const isLargeScreen =
+    useBreakpointValue({
+      base: false,
+      md: false,
+      lg: true,
+    }) ?? false;
+
+  const { isPanelOpen, setIsPanelOpen } = useOutletContext<{
+    isPanelOpen: boolean;
+    setIsPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  }>();
+
+  useEffect(() => {
+    setIsPanelOpen(isLargeScreen);
+  }, [isLargeScreen, setIsPanelOpen]);
+
   const [isDismissed, setIsDismissed] = useState<boolean>(() =>
     typeof window !== "undefined" ? isWelcomeHidden() : false,
   );
@@ -17,11 +35,20 @@ export function WelcomePanel() {
   if (isDismissed) return null;
 
   return (
-    <Accordion defaultIndex={[0]} allowToggle width={"100%"} maxHeight={"100%"}>
-      <AccordionItem border="none">
+    <Accordion
+      allowToggle
+      width={"100%"}
+      maxHeight={{ base: "full", lg: "100%" }}
+      index={isPanelOpen ? 0 : -1}
+      onChange={(nextIndex) => {
+        setIsPanelOpen(nextIndex === 0);
+      }}
+      className={"welcomeContainer"}
+    >
+      <AccordionItem border={"none"}>
         <AccordionButton padding="0px" aria-label="Toggle project list panel">
           <WelcomeHeader />
-          <AccordionIcon size="lg" />
+          <AccordionIcon size={"lg"} />
         </AccordionButton>
         <AccordionPanel
           padding={"0px"}

--- a/app/layouts/MapPage.tsx
+++ b/app/layouts/MapPage.tsx
@@ -14,6 +14,7 @@ import {
   Tab,
   TabList,
   Tabs,
+  useBreakpointValue,
 } from "@nycplanning/streetscape";
 import {
   Outlet,
@@ -59,7 +60,7 @@ import type { RootContextType } from "../root";
 import { MapViewControls } from "~/components/MapViewControls";
 import { SearchByCbbrMenu } from "~/components/SearchByCbbrMenu";
 import { SearchByFacilityMenu } from "~/components/SearchByFacilityMenu";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useStore } from "~/store";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
@@ -434,6 +435,37 @@ export default function MapPage() {
     }
   };
 
+  const isLargeScreen =
+    useBreakpointValue({
+      base: false,
+      md: true,
+      lg: true,
+    }) ?? false;
+
+  const [layersAccordionIndex, setLayersAccordionIndex] = useState<number[]>(
+    [],
+  );
+
+  // accordian panel mobile collapse
+  const previousIsLargeScreen = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    if (previousIsLargeScreen.current === isLargeScreen) {
+      return;
+    }
+
+    previousIsLargeScreen.current = isLargeScreen;
+
+    setLayersAccordionIndex(isLargeScreen ? [0] : []);
+  }, [isLargeScreen]);
+
+  // results panel mobile collapse
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+
+  useEffect(() => {
+    setIsPanelOpen(isLargeScreen);
+  }, [isLargeScreen]);
+
   const [savedGeoSelection, setSavedGeoSelection] = useState<{
     cd: { communityDistrictIds: string } | undefined;
     ccd: { cityCouncilDistrictIds: string } | undefined;
@@ -445,9 +477,10 @@ export default function MapPage() {
       <GridItem
         gridColumn={"1 / -1"}
         gridRow={{
-          base: "2 / 7",
-          md: "2 / -1",
+          base: "header-end / atlas-end",
+          md: "header-end / -1",
         }}
+        className={"atlasContainer"}
       >
         <Atlas
           viewState={viewState}
@@ -464,7 +497,11 @@ export default function MapPage() {
       <GridItem
         bgColor="white"
         borderRadius="lg"
-        gridRowStart={3}
+        gridRowStart={{
+          base: "base-start",
+          md: "base-start",
+          lg: "row-start",
+        }}
         gridColumn={{
           base: "col-start / span 8",
           md: "col-start / span 7",
@@ -472,6 +509,7 @@ export default function MapPage() {
           "2xl": "4 / span 7",
         }}
         height={"fit-content"}
+        className={"tabsContainer"}
       >
         <Tabs
           variant={"mapControl"}
@@ -631,9 +669,9 @@ export default function MapPage() {
           "2xl": "col-start / span 2",
         }}
         gridRow={{
-          base: "5 / row-end",
-          md: "5 / row-end",
-          xl: "3 / span 3",
+          base: "base-end / row-end",
+          lg: "base-start / row-end",
+          xl: "row-start / span 3",
         }}
         height={"fit-content"}
         maxHeight={"100%"}
@@ -641,6 +679,7 @@ export default function MapPage() {
         sx={{
           scrollbarWidth: "none",
         }}
+        className={"filtersContainer"}
       >
         <Flex
           direction={"column"}
@@ -648,9 +687,9 @@ export default function MapPage() {
           alignItems={"center"}
           flexShrink={{ lg: 0 }}
           maxHeight={{
-            base: "82vh",
-            lg: "84vh",
-            xl: "89vh",
+            base: "82dvh",
+            lg: "84dvh",
+            xl: "89dvh",
           }}
           backgroundColor={"white"}
           borderRadius={10}
@@ -661,7 +700,14 @@ export default function MapPage() {
           }}
           boxShadow={"0 2px 8px 0 rgba(0, 0, 0, 0.20)"}
         >
-          <Accordion allowMultiple defaultIndex={[0]} width={"100%"}>
+          <Accordion
+            allowMultiple
+            width={"100%"}
+            index={layersAccordionIndex}
+            onChange={(nextIndex) => {
+              setLayersAccordionIndex(nextIndex as number[]);
+            }}
+          >
             <AccordionItem borderTop={"none"} borderBottom={"none"}>
               <AccordionButton p={0} aria-label="Toggle layers panel">
                 <Heading
@@ -815,10 +861,12 @@ export default function MapPage() {
       <GridItem
         gridColumnStart={{ base: 9, md: 7, lg: 6, xl: 5, "2xl": 4 }}
         gridRow={{
-          base: "5 / span 1",
+          base: "base-end / span 1",
+          lg: "base-start / span 1",
         }}
         width={"fit-content"}
         height={"fit-content"}
+        className={"mapControlsContainer"}
       >
         <MapViewControls
           viewState={viewState}
@@ -848,32 +896,40 @@ export default function MapPage() {
         display={"flex"}
         flexDirection={"column"}
         justifyContent={{ base: "end", lg: "start" }}
+        className={"resultsContainer"}
       >
         <Flex
           width={"full"}
           gap={3}
-          pointerEvents={"none"}
+          pointerEvents={"auto"}
           sx={{
-            "> *": {
-              pointerEvents: "auto",
-            },
             scrollbarWidth: "none",
           }}
           direction={"column"}
           flexShrink={{ lg: 0 }}
-          maxHeight={"full"}
+          maxHeight={{
+            base: isPanelOpen ? "70dvh" : "64px",
+            lg: "full",
+          }}
+          opacity={1}
+          overflowY={isPanelOpen ? "scroll" : "hidden"}
           justify={"end"}
           backgroundColor={"white"}
-          borderRadius={10}
-          overflowY={"scroll"}
+          borderRadius={{
+            base: "10px 10px 0 0",
+            lg: "10px",
+          }}
           padding={4}
           boxShadow={"0 8px 4px 0 rgba(0, 0, 0, 0.08)"}
+          transition={"max-height 0.1s ease"}
         >
           <Outlet
             context={{
               hoveredOverItem,
               setHoveredOverItem,
               clearRadiusFilter,
+              isPanelOpen,
+              setIsPanelOpen,
             }}
           />
         </Flex>

--- a/app/layouts/NonMapPage.tsx
+++ b/app/layouts/NonMapPage.tsx
@@ -5,47 +5,47 @@ export default function NonMapHeaderPage() {
   return (
     <Grid
       templateColumns={"subgrid"}
-      templateRows={"subgrid"}
-      gridColumn={"1 / -1"}
-      gridRow={"2 / -1"}
+      gridColumn="1 / -1"
+      gridRow="header-end / -1"
+      overflowY="auto"
+      sx={{
+        scrollbarWidth: "none",
+      }}
+      className={"nonMapPage"}
     >
       <GridItem
-        gridColumnStart={{
-          base: "2",
-          lg: "3",
-          xl: "4",
+        gridColumn={{
+          base: "2 / -2",
+          lg: "3 / 10",
+          xl: "4 / 9",
         }}
-        gridColumnEnd={{
-          base: "-2",
-          lg: "10",
-          xl: "9",
+        gridRow={{
+          base: "row-start",
+          lg: "row-start / row-end",
         }}
-        gridRowStart={"2"}
-        gridRowEnd={"3"}
         pt={8}
+        minHeight={0}
+        className={"aboutContentContainer"}
       >
         <Outlet />
       </GridItem>
+
       <GridItem
-        gridColumnStart={{
-          base: "2",
-          lg: "10",
-          xl: "9",
+        gridColumn={{
+          base: "2 / -2",
+          lg: "10 / 12",
+          xl: "9 / 12",
         }}
-        gridColumnEnd={{
-          base: "-2",
-          lg: "12",
-          xl: "12",
+        gridRow={{
+          base: "auto",
+          lg: "row-start / row-end",
         }}
-        gridRowStart={{
-          base: "3",
-          lg: "2",
+        pt={{
+          base: 0,
+          lg: 8,
         }}
-        gridRowEnd={{
-          base: "4",
-          lg: "3",
-        }}
-        pt={8}
+        minHeight={0}
+        className={"feedbackContainer"}
       >
         <VStack
           alignItems={"flex-start"}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -283,10 +283,12 @@ export default function App() {
                 "2xl": "0 0.78dw",
               }}
               templateRows={{
-                base: "7dvh 2dvh [row-start] min-content 2dvh 1fr [row-end] 2dvh 7dvh",
-                md: "7dvh 2dvh [row-start] min-content 2dvh 1fr [row-end] 2dvh",
+                base: "7dvh [header-end] 2dvh [row-start] min-content [line] 2dvh [base-start] 7dvh [base-end] 2dvh 1fr [row-end] 2dvh [atlas-end] 7dvh",
+                md: "7dvh [header-end] 2dvh [row-start] min-content 2dvh [base-start] 7dvh [base-end] 2dvh 1fr [row-end] 2dvh",
+                lg: "7dvh [header-end] 2dvh [row-start] min-content 2dvh [base-start] 1fr [row-end] 2dvh",
               }}
-              height="100vh"
+              height="100dvh"
+              className={"rootContainer"}
             >
               <QueryClientProvider client={queryClient}>
                 <Main />


### PR DESCRIPTION
#### Description
- add new rows and rename rows in  Root container
- Move GridItems to new grid row lines and propagating to children where needed. 
- Adjustments to default open/closed states of the filter and results panels on `base` and `md` screens

<details>
<summary>Notes: </summary>
I kept the class names because it makes troubleshooting and debugging much easier especially in the dev tools console as shown in the screenshots below.

<img width="641" height="167" alt="Screenshot 2026-07-24 at 9 51 06 AM" src="https://github.com/user-attachments/assets/895b63ab-4113-4969-b3a4-9ed41bd98e91" />

<img width="628" height="62" alt="Screenshot 2026-07-24 at 9 52 46 AM" src="https://github.com/user-attachments/assets/9d2872f2-6122-4df6-9f0a-81529c8bd7a4" />


#### Design Approval

<img width="1040" height="387" alt="Screenshot 2026-07-24 at 1 09 21 PM" src="https://github.com/user-attachments/assets/153e8f97-3fb6-40a1-94d2-a08d020f66b6" />

</details>
#### Tickets
Closes #428 